### PR TITLE
SCOPFLOW HiOp Patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ install/*
 .ubuild.json
 *__pycache__*
 *nvblas.conf
-spack*
+spack-*
+spack.*
 .vscode/
 coinhsl-*
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ install/*
 *__pycache__*
 *nvblas.conf
 spack-*
-spack.*
 .vscode/
 coinhsl-*
 node_modules

--- a/buildsystem/spack/ascent/spack.yaml
+++ b/buildsystem/spack/ascent/spack.yaml
@@ -41,7 +41,7 @@ spack:
     exago:
       require: +raja+hiop+ipopt
     hiop:
-      require: '@1.0.0+sparse+mpi+ginkgo+kron+cusolver_lu'
+      require: '@develop+sparse+mpi+ginkgo+kron+cusolver_lu'
     coinhsl:
       require: '@2019.05.21'
     ipopt:

--- a/buildsystem/spack/deception/spack.yaml
+++ b/buildsystem/spack/deception/spack.yaml
@@ -19,7 +19,7 @@ spack:
     exago:
       require: +raja+hiop+ipopt
     hiop:
-      require: '@1.0.0+sparse+mpi+ginkgo+kron'
+      require: '@develop+sparse+mpi+ginkgo+kron'
     magma:
       require: '@2.6.2'
     coinhsl:

--- a/buildsystem/spack/incline/modules/dependencies.sh
+++ b/buildsystem/spack/incline/modules/dependencies.sh
@@ -95,5 +95,5 @@ module load ipopt/3.12.10-clang-15.0.0-rocm5.3.0-7o6pau6
 module load python/3.11.4-clang-15.0.0-rocm5.3.0-hpuu3g4
 # petsc@=3.18.6%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos7-zen
 module load petsc/3.18.6-clang-15.0.0-rocm5.3.0-42hbmrj
-# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/23508/spack_incline generator=make arch=linux-centos7-zen
-## module load exago/develop-clang-15.0.0-rocm5.3.0-fzoncup
+# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/25308/spack_incline generator=make arch=linux-centos7-zen
+## module load exago/develop-clang-15.0.0-rocm5.3.0-n5ll2cc

--- a/buildsystem/spack/incline/modules/exago.sh
+++ b/buildsystem/spack/incline/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /qfs/projects/exasgd/src/ci-incline/install/modules/linux-centos7-zen
-# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/23508/spack_incline generator=make arch=linux-centos7-zen
-module load exago/develop-clang-15.0.0-rocm5.3.0-fzoncup
+# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/25308/spack_incline generator=make arch=linux-centos7-zen
+module load exago/develop-clang-15.0.0-rocm5.3.0-n5ll2cc

--- a/buildsystem/spack/incline/spack.yaml
+++ b/buildsystem/spack/incline/spack.yaml
@@ -57,7 +57,7 @@ spack:
     hiop:
     # TODO - build with Ginkgo #463
     # TODO - updgrade to develop / 1.0.0 #28
-      require: '@1.0.0+sparse+mpi+raja+rocm~ginkgo+kron'
+      require: '@develop+sparse+mpi+raja+rocm~ginkgo+kron'
     ipopt:
       require: '@3.12.10~metis+coinhsl~mumps'
     # Pin version of OpenBlas for testing results

--- a/buildsystem/spack/newell/spack.yaml
+++ b/buildsystem/spack/newell/spack.yaml
@@ -19,7 +19,7 @@ spack:
     exago:
       require: +raja+hiop+ipopt
     hiop:
-      require: '@1.0.0+sparse+mpi+ginkgo+kron'
+      require: '@develop+sparse+mpi+ginkgo+kron'
     magma:
       require: '@2.6.2'
     coinhsl:

--- a/src/scopflow/solver/hiop/scopflow_hiop.cpp
+++ b/src/scopflow/solver/hiop/scopflow_hiop.cpp
@@ -155,7 +155,7 @@ extern PetscErrorCode SCOPFLOWUpdateOPFLOWVariableBounds(OPFLOW, Vec, Vec,
 /* Note: x only holds the coupled variables which, in this case, are the
    generator real power variables for the base-case
 */
-bool SCOPFLOWHIOPInterface::eval_f_rterm(size_t idx, const int &n,
+bool SCOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
                                          const double *x, double &rval) {
   PetscErrorCode ierr;
   OPFLOW opflow0; /* base case OPFLOW */
@@ -245,7 +245,7 @@ bool SCOPFLOWHIOPInterface::eval_f_rterm(size_t idx, const int &n,
   return true;
 }
 
-bool SCOPFLOWHIOPInterface::eval_grad_rterm(size_t idx, const int &n, double *x,
+bool SCOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                                             hiop::hiopVector &gradvec) {
   (void)idx;
   (void)n;
@@ -310,12 +310,12 @@ bool SCOPFLOWHIOPInterface::eval_grad_rterm(size_t idx, const int &n, double *x,
   return true;
 }
 
-size_t SCOPFLOWHIOPInterface::get_num_rterms() const {
-  return scopflow->Nc - 1;
+hiop::size_type SCOPFLOWHIOPInterface::get_num_rterms() const {
+  return (hiop::size_type) scopflow->Nc - 1;
 }
 
-size_t SCOPFLOWHIOPInterface::get_num_vars() const {
-  return scopflow->opflow0->nx;
+hiop::size_type SCOPFLOWHIOPInterface::get_num_vars() const {
+  return (hiop::size_type) scopflow->opflow0->nx;
 }
 
 void SCOPFLOWHIOPInterface::get_solution(double *x) const {

--- a/src/scopflow/solver/hiop/scopflow_hiop.cpp
+++ b/src/scopflow/solver/hiop/scopflow_hiop.cpp
@@ -245,7 +245,8 @@ bool SCOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   return true;
 }
 
-bool SCOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
+bool SCOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n,
+                                            double *x,
                                             hiop::hiopVector &gradvec) {
   (void)idx;
   (void)n;
@@ -311,11 +312,11 @@ bool SCOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n, d
 }
 
 hiop::size_type SCOPFLOWHIOPInterface::get_num_rterms() const {
-  return (hiop::size_type) scopflow->Nc - 1;
+  return (hiop::size_type)scopflow->Nc - 1;
 }
 
 hiop::size_type SCOPFLOWHIOPInterface::get_num_vars() const {
-  return (hiop::size_type) scopflow->opflow0->nx;
+  return (hiop::size_type)scopflow->opflow0->nx;
 }
 
 void SCOPFLOWHIOPInterface::get_solution(double *x) const {

--- a/src/scopflow/solver/hiop/scopflow_hiop.h
+++ b/src/scopflow/solver/hiop/scopflow_hiop.h
@@ -23,7 +23,8 @@ public:
                                      const double *hess,
                                      const char *master_options_file);
 
-  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x, double &rval);
+  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x,
+                    double &rval);
   bool eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                        hiop::hiopVector &grad);
 

--- a/src/scopflow/solver/hiop/scopflow_hiop.h
+++ b/src/scopflow/solver/hiop/scopflow_hiop.h
@@ -23,13 +23,13 @@ public:
                                      const double *hess,
                                      const char *master_options_file);
 
-  bool eval_f_rterm(size_t idx, const int &n, const double *x, double &rval);
-  bool eval_grad_rterm(size_t idx, const int &n, double *x,
+  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x, double &rval);
+  bool eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                        hiop::hiopVector &grad);
 
-  size_t get_num_rterms() const;
+  hiop::size_type get_num_rterms() const;
 
-  size_t get_num_vars() const;
+  hiop::size_type get_num_vars() const;
 
   void get_solution(double *x) const;
 

--- a/src/sopflow/solver/hiop/sopflow_hiop.cpp
+++ b/src/sopflow/solver/hiop/sopflow_hiop.cpp
@@ -283,7 +283,8 @@ bool SOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
   return true;
 }
 
-bool SOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
+bool SOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n,
+                                           double *x,
                                            hiop::hiopVector &gradvec) {
   (void)idx;
   (void)n;

--- a/src/sopflow/solver/hiop/sopflow_hiop.cpp
+++ b/src/sopflow/solver/hiop/sopflow_hiop.cpp
@@ -164,7 +164,7 @@ extern PetscErrorCode SOPFLOWUpdateOPFLOWVariableBounds(OPFLOW, Vec, Vec,
 /* Note: x only holds the coupled variables which, in this case, are the
    generator real power variables for the base-case
 */
-bool SOPFLOWHIOPInterface::eval_f_rterm(size_t idx, const int &n,
+bool SOPFLOWHIOPInterface::eval_f_rterm(hiop::size_type idx, const int &n,
                                         const double *x, double &rval) {
   (void)n;
   PetscErrorCode ierr;
@@ -283,7 +283,7 @@ bool SOPFLOWHIOPInterface::eval_f_rterm(size_t idx, const int &n,
   return true;
 }
 
-bool SOPFLOWHIOPInterface::eval_grad_rterm(size_t idx, const int &n, double *x,
+bool SOPFLOWHIOPInterface::eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                                            hiop::hiopVector &gradvec) {
   (void)idx;
   (void)n;
@@ -349,11 +349,11 @@ bool SOPFLOWHIOPInterface::eval_grad_rterm(size_t idx, const int &n, double *x,
   return true;
 }
 
-size_t SOPFLOWHIOPInterface::get_num_rterms() const {
+hiop::size_type SOPFLOWHIOPInterface::get_num_rterms() const {
   return (sopflow->Ns * sopflow->Nc) - 1;
 }
 
-size_t SOPFLOWHIOPInterface::get_num_vars() const {
+hiop::size_type SOPFLOWHIOPInterface::get_num_vars() const {
   return sopflow->opflow0->nx;
 }
 

--- a/src/sopflow/solver/hiop/sopflow_hiop.h
+++ b/src/sopflow/solver/hiop/sopflow_hiop.h
@@ -24,7 +24,8 @@ public:
                                      const double *hess,
                                      const char *master_options_file);
 
-  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x, double &rval);
+  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x,
+                    double &rval);
   bool eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                        hiop::hiopVector &grad);
 

--- a/src/sopflow/solver/hiop/sopflow_hiop.h
+++ b/src/sopflow/solver/hiop/sopflow_hiop.h
@@ -24,13 +24,13 @@ public:
                                      const double *hess,
                                      const char *master_options_file);
 
-  bool eval_f_rterm(size_t idx, const int &n, const double *x, double &rval);
-  bool eval_grad_rterm(size_t idx, const int &n, double *x,
+  bool eval_f_rterm(hiop::size_type idx, const int &n, const double *x, double &rval);
+  bool eval_grad_rterm(hiop::size_type idx, const int &n, double *x,
                        hiop::hiopVector &grad);
 
-  size_t get_num_rterms() const;
+  hiop::size_type get_num_rterms() const;
 
-  size_t get_num_vars() const;
+  hiop::size_type get_num_vars() const;
 
   void get_solution(double *x) const;
 

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -113,13 +113,6 @@ if(EXAGO_INSTALL_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_cont_mpi.toml
   )
 
-  if(EXAGO_ENABLE_IPOPT AND EXAGO_ENABLE_HIOP)
-    set_tests_properties(
-      FUNCTIONALITY_TEST_SCOPFLOW_HIOP_MPI_TESTSUITE PROPERTIES LABELS
-                                                                "incline-skip"
-    )
-  endif()
-
   exago_add_test(
     NAME
     FUNCTIONALITY_TEST_SCOPFLOW_HIOP_SERIAL_TESTSUITE
@@ -147,7 +140,7 @@ if(EXAGO_INSTALL_TESTS)
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_raja.toml
   )
-  
+
   foreach(fmt "MATPOWER" "CSV" "JSON" "MINIMAL")
     set(tname "SCOPFLOW_SOLUTION_OUTPUT_${fmt}")
     exago_add_test(

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -147,11 +147,7 @@ if(EXAGO_INSTALL_TESTS)
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_raja.toml
   )
-  set_tests_properties(
-    FUNCTIONALITY_TEST_SCOPFLOW_HIOP_RAJA_TESTSUITE PROPERTIES LABELS
-                                                               "incline-skip"
-  )
-
+  
   foreach(fmt "MATPOWER" "CSV" "JSON" "MINIMAL")
     set(tname "SCOPFLOW_SOLUTION_OUTPUT_${fmt}")
     exago_add_test(

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -84,13 +84,6 @@ if(EXAGO_INSTALL_TESTS)
     HOST
   )
 
-  if(EXAGO_ENABLE_IPOPT AND EXAGO_ENABLE_HIOP)
-    set_tests_properties(
-      FUNCTIONALITY_TEST_SCOPFLOW_HIOP_PBHIOP_TESTSUITE
-      PROPERTIES LABELS "newell-skip;deception-skip"
-    )
-  endif()
-
   exago_add_test(
     NAME
     FUNCTIONALITY_TEST_SCOPFLOW_HIOP_PBHIOP_MPI_TESTSUITE
@@ -141,13 +134,6 @@ if(EXAGO_INSTALL_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_serial.toml
   )
 
-  if(EXAGO_ENABLE_IPOPT AND EXAGO_ENABLE_HIOP)
-    set_tests_properties(
-      FUNCTIONALITY_TEST_SCOPFLOW_HIOP_SERIAL_TESTSUITE
-      PROPERTIES LABELS "incline-skip;deception-skip"
-    )
-  endif()
-
   exago_add_test(
     NAME
     FUNCTIONALITY_TEST_SCOPFLOW_HIOP_RAJA_TESTSUITE
@@ -161,13 +147,10 @@ if(EXAGO_INSTALL_TESTS)
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_raja.toml
   )
-
-  if(EXAGO_ENABLE_IPOPT AND EXAGO_ENABLE_HIOP)
-    set_tests_properties(
-      FUNCTIONALITY_TEST_SCOPFLOW_HIOP_RAJA_TESTSUITE
-      PROPERTIES LABELS "incline-skip;deception-skip"
-    )
-  endif()
+  set_tests_properties(
+    FUNCTIONALITY_TEST_SCOPFLOW_HIOP_RAJA_TESTSUITE PROPERTIES LABELS
+                                                               "incline-skip"
+  )
 
   foreach(fmt "MATPOWER" "CSV" "JSON" "MINIMAL")
     set(tname "SCOPFLOW_SOLUTION_OUTPUT_${fmt}")


### PR DESCRIPTION
Initial Purpose: Fix divide by zero errors happening in SCOPFLOW - a hiop patch issue657-fix was added to resolve these issues. Just rebuilding with updated hiop and re-enabling those tests.
-> these errors were fixed in hiop@1.0.0

Current Purpose: build with hiop@develop (v1.0.1+) and resolve issues due to interface changes and compiler warnings.


Closes #3 