### PR TITLE
Only check for Python if it is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,8 +406,8 @@ else()
   endif()
 endif()
 
-include(ExaGOCheckPython)
 if(EXAGO_ENABLE_PYTHON)
+  include(ExaGOCheckPython)
   # Build pybind11 target manually
   add_subdirectory(tpl/pybind11)
   add_subdirectory(interfaces/python)


### PR DESCRIPTION
Since #48 was identified, I realize that fixing builds `+python~mpi` #16 would entail closing #48, so this is a more modest PR just to resolve #44 

We have a spack pipeline that should catch this error in theory, but it is picking up the system python, so only xSDK pipelines seem to be reproducers at this point. I don't think it is worth the time to develop pipelines to repro this since it is a small fix and we have a release coming.