### PR TITLE
Fix Ascent Logger Test

### DIFF
--- a/buildsystem/gcc-cuda/ascent/base.sh
+++ b/buildsystem/gcc-cuda/ascent/base.sh
@@ -2,8 +2,6 @@
 
 export MY_CLUSTER=ascent
 
-module reset
-
 # Load system modules
 module load gcc/11.2.0
 module load spectrum-mpi/10.4.0.3-20210112

--- a/buildsystem/gcc-cuda/ascentVariables.sh
+++ b/buildsystem/gcc-cuda/ascentVariables.sh
@@ -8,4 +8,3 @@ source $SRCDIR/buildsystem/spack/$MY_CLUSTER/modules/dependencies.sh
 
 # Shared system configuration
 source $SRCDIR/buildsystem/gcc-cuda/ascent/base.sh
-

--- a/buildsystem/gcc-cuda/ascentVariables.sh
+++ b/buildsystem/gcc-cuda/ascentVariables.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 export SRCDIR=${SRCDIR:-$PWD}
-
-# Shared system configuration
-source $SRCDIR/buildsystem/gcc-cuda/ascent/base.sh
+export MY_CLUSTER=ascent
 
 # Spack modules
 source $SRCDIR/buildsystem/spack/$MY_CLUSTER/modules/dependencies.sh
 
-module load spectrum-mpi/10.4.0.3-20210112
+# Shared system configuration
+source $SRCDIR/buildsystem/gcc-cuda/ascent/base.sh
+

--- a/buildsystem/gcc-cuda/ascentVariables.sh
+++ b/buildsystem/gcc-cuda/ascentVariables.sh
@@ -7,3 +7,5 @@ source $SRCDIR/buildsystem/gcc-cuda/ascent/base.sh
 
 # Spack modules
 source $SRCDIR/buildsystem/spack/$MY_CLUSTER/modules/dependencies.sh
+
+module load spectrum-mpi/10.4.0.3-20210112

--- a/buildsystem/spack/ascent/modules/dependencies.sh
+++ b/buildsystem/spack/ascent/modules/dependencies.sh
@@ -37,8 +37,6 @@ module load magma/2.6.2-gcc-11.2.0-tiugqi3
 module load metis/5.1.0-gcc-11.2.0-phx5jh2
 # raja@=0.14.0%gcc@=11.2.0+cuda~examples~exercises~ipo+openmp~rocm+shared~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel8-power9le
 module load raja/0.14.0-gcc-11.2.0-6kcew5j
-# spectrum-mpi@=10.4.0.3-20210112%gcc@=11.2.0 build_system=bundle arch=linux-rhel8-power9le
-module load spectrum-mpi/10.4.0.3-20210112-gcc-11.2.0-jflmvka
 # gmp@=6.2.1%gcc@=11.2.0+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-rhel8-power9le
 module load gmp/6.2.1-gcc-11.2.0-acpul5s
 # diffutils@=3.9%gcc@=11.2.0 build_system=autotools arch=linux-rhel8-power9le

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -52,7 +52,4 @@ if(EXAGO_INSTALL_TESTS)
     LOGGING
   )
 
-  if(EXAGO_ENABLE_LOGGING)
-    set_tests_properties(UNIT_TESTS_LOGGER PROPERTIES LABELS "ascent-skip")
-  endif()
 endif()


### PR DESCRIPTION
closes #42 

Somehow even after deleting the spack built mpi, the something in `dependencies.sh` [is still loading it ](https://code.ornl.gov/ecpcitest/exasgd/exago/-/jobs/2083092#L64)so I forced loading the system module afterwards and that fixes it. I am aware that this is a little janky.