### PR TITLE
Use #if defined instead of #if and turn off -Werror for debug builds

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -33,10 +33,10 @@ exago_add_library(
 # works -Wpedantic for CUDA compile options added a significant amount of new
 # errors, so leaving out for now
 set(CUDA_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Werror,-Wall,-Wextra>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
 )
 set(CXX_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Werror;-Wall;-Wextra;-Wpedantic>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Wall;-Wextra;-Wpedantic>"
 )
 if(EXAGO_BUILD_SHARED)
   target_compile_options(

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -30,9 +30,9 @@ exago_add_library(
 )
 
 # Going to have this target supply/propogate compiler flags and see if that
-# works -Wpedantic for CUDA compile options added a significant amount of new
-# errors, so leaving out for now -Werror is problematic on MacOS
-if(APPLE)
+# works. -Wpedantic for CUDA compile options added a significant amount of new
+# errors, so leaving out for now. -Werror is problematic on MacOS
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
   set(CUDA_COMPILE_OPTIONS
       "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
   )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -31,13 +31,23 @@ exago_add_library(
 
 # Going to have this target supply/propogate compiler flags and see if that
 # works -Wpedantic for CUDA compile options added a significant amount of new
-# errors, so leaving out for now
-set(CUDA_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
-)
-set(CXX_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Wall;-Wextra;-Wpedantic>"
-)
+# errors, so leaving out for now -Werror is problematic on MacOS
+if(APPLE)
+  set(CUDA_COMPILE_OPTIONS
+      "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
+  )
+  set(CXX_COMPILE_OPTIONS
+      "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Wall;-Wextra;-Wpedantic>"
+  )
+else()
+  set(CUDA_COMPILE_OPTIONS
+      "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Werror,-Wall,-Wextra>"
+  )
+  set(CXX_COMPILE_OPTIONS
+      "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Werror;-Wall;-Wextra;-Wpedantic>"
+  )
+endif()
+
 if(EXAGO_BUILD_SHARED)
   target_compile_options(
     UTILS_shared PUBLIC ${CUDA_COMPILE_OPTIONS} ${CXX_COMPILE_OPTIONS}

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -17,11 +17,11 @@
 #include <sys/utsname.h>
 #include <version.h>
 #include <utils.h>
-#if (EXAGO_ENABLE_IPOPT || EXAGO_ENABLE_HIOP)
+#if defined EXAGO_ENABLE_IPOPT || defined EXAGO_ENABLE_HIOP
 #include <opflow.h>
 #endif
 
-#if (EXAGO_ENABLE_IPOPT)
+#if defined EXAGO_ENABLE_IPOPT
 #include <sopflow.h>
 #include <scopflow.h>
 #endif
@@ -373,7 +373,7 @@ template <typename T> static inline void print(T const &opt) {
   // See comment at ExaGODefaultOptions
   // print(O::network);
 
-#if (EXAGO_ENABLE_IPOPT || EXAGO_ENABLE_HIOP)
+#if defined EXAGO_ENABLE_IPOPT || defined EXAGO_ENABLE_HIOP
   if (appname == "opflow") {
     print(OPFLOWOptions::model);
     print(OPFLOWOptions::solver);
@@ -408,7 +408,7 @@ template <typename T> static inline void print(T const &opt) {
     // fprintf(stderr, "\n");
   } else if (appname == "pflow") {
     /* pflow application driver does not take any additional arguments */
-#if (EXAGO_ENABLE_IPOPT)
+#if defined EXAGO_ENABLE_IPOPT
   } else if (appname == "sopflow") {
     print(SOPFLOWOptions::sopflow_model);
     print(SOPFLOWOptions::sopflow_solver);


### PR DESCRIPTION
`#if` does not work correctly on Mac so switching to `#if defined`. Noticed this behavior for
`#if (EXAGO_ENABLE_IPOPT || EXAGO_ENABLE_HIOP)` so replaced it with
`#if  defined EXAGO_ENABLE_IPOPT || defined EXAGO_ENABLE_HIOP`.

Also removed the `-Werror` flag for debug builds. `sprintf` is depecreated for clang and so `-Werror` flag results in zillions of errors. Note that the error is thrown not only for `sprintf` in ExaGO code, but also if it is any dependency library. Need to tackle this through a separate issue so turning off the `-Werror` for now.