### PR TITLE
Fix ignoring contingencies when the from bus number is greater than than to bus number

### DIFF
--- a/src/ps/ps.cpp
+++ b/src/ps/ps.cpp
@@ -279,8 +279,8 @@ PetscErrorCode PSGetLine(PS ps, PetscInt fbus, PetscInt tbus, const char *id,
     ierr = PSBUSGetSupportingLines(bus, &nsupplines, &supplines);
     CHKERRQ(ierr);
     for (i = 0; i < nsupplines; i++) {
-      if (supplines[i]->fbus == fbus && supplines[i]->tbus == tbus) {
-        ierr = PetscStrcmp(id, supplines[i]->ckt, &flg);
+      if ((supplines[i]->fbus == fbus && supplines[i]->tbus == tbus) ||  (supplines[i]->reversed_ends & (supplines[i]->fbus == tbus && supplines[i]->tbus == fbus))) {
+	ierr = PetscStrcmp(id, supplines[i]->ckt, &flg);
         CHKERRQ(ierr);
         if (flg) {
           *line = supplines[i];

--- a/src/ps/ps.cpp
+++ b/src/ps/ps.cpp
@@ -279,8 +279,10 @@ PetscErrorCode PSGetLine(PS ps, PetscInt fbus, PetscInt tbus, const char *id,
     ierr = PSBUSGetSupportingLines(bus, &nsupplines, &supplines);
     CHKERRQ(ierr);
     for (i = 0; i < nsupplines; i++) {
-      if ((supplines[i]->fbus == fbus && supplines[i]->tbus == tbus) ||  (supplines[i]->reversed_ends & (supplines[i]->fbus == tbus && supplines[i]->tbus == fbus))) {
-	ierr = PetscStrcmp(id, supplines[i]->ckt, &flg);
+      if ((supplines[i]->fbus == fbus && supplines[i]->tbus == tbus) ||
+          (supplines[i]->reversed_ends &
+           (supplines[i]->fbus == tbus && supplines[i]->tbus == fbus))) {
+        ierr = PetscStrcmp(id, supplines[i]->ckt, &flg);
         CHKERRQ(ierr);
         if (flg) {
           *line = supplines[i];

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -33,10 +33,10 @@ exago_add_library(
 # works -Wpedantic for CUDA compile options added a significant amount of new
 # errors, so leaving out for now
 set(CUDA_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Werror,-Wall,-Wextra>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
 )
 set(CXX_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Werror;-Wall;-Wextra;-Wpedantic>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Wall;-Wextra;-Wpedantic>"
 )
 if(EXAGO_BUILD_SHARED)
   target_compile_options(

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -33,10 +33,10 @@ exago_add_library(
 # works -Wpedantic for CUDA compile options added a significant amount of new
 # errors, so leaving out for now
 set(CUDA_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Wall,-Wextra>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:DEBUG>>:SHELL:--compiler-options -Werror,-Wall,-Wextra>"
 )
 set(CXX_COMPILE_OPTIONS
-    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Wall;-Wextra;-Wpedantic>"
+    "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>:-Werror;-Wall;-Wextra;-Wpedantic>"
 )
 if(EXAGO_BUILD_SHARED)
   target_compile_options(


### PR DESCRIPTION
Fixes #26 

When the from bus number is greater than the to bus number for a branch, the PS branch object stores it in the reverse order. This is done so that the from bus number is always less than to bus number. The reason for doing this is IPOPT complains for Hessian if this is not done. However, this was causing the contingencies with from bus > to bus to be ignored.

Fixed this issue by having the `PSGetLine` routine check for both the combinations (from bus -- to bus, and to bus -- from bus) 