### PR TITLE
Build with rocm/5.6 on Frontier (~ginkgo)

### DIFF
--- a/buildsystem/clang-hip/cache.cmake
+++ b/buildsystem/clang-hip/cache.cmake
@@ -1,4 +1,4 @@
-message(STATUS "Loading CMake cache for a GCC+CUDA+MPI build")
+message(STATUS "Loading CMake cache for a GCC+HIP+MPI build")
 
 set(prefix ${CMAKE_SOURCE_DIR}/install)
 message(STATUS "Setting initial installation prefix to ${prefix}")

--- a/buildsystem/clang-hip/crusher/base.sh
+++ b/buildsystem/clang-hip/crusher/base.sh
@@ -9,15 +9,15 @@ module reset
 module load PrgEnv-gnu-amd
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
-module load amd-mixed/5.2.0
+module load amd-mixed/5.6.0
 module load gcc/12.2.0
 module load cray-mpich/8.1.25
 module load libfabric
 
 # Consider changing to $(which clang) as for deception
-export CC=/opt/rocm-5.2.0/llvm/bin/amdclang
-export CXX=/opt/rocm-5.2.0/llvm/bin/amdclang++
-export FC=/opt/rocm-5.2.0/llvm/bin/amdflang
+export CC=/opt/rocm-5.6.0/llvm/bin/amdclang
+export CXX=/opt/rocm-5.6.0/llvm/bin/amdclang++
+export FC=/opt/rocm-5.6.0/llvm/bin/amdflang
 
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DEXAGO_CTEST_LAUNCH_COMMAND='srun'"
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DAMDGPU_TARGETS='gfx90a'"

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,67 +1,99 @@
 module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
-# pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-vp3ll6l
-# nghttp2@=1.52.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load nghttp2/1.52.0-clang-16.0.0-rocm5.6.0-mixed-prks6rd
-# ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-zen3
-module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-swebvgy
-# perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-zen3
-module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-hyokfvp
-# zlib-ng@=2.1.3%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools patches=299b958,ae9077a,b692621 arch=linux-sles15-zen3
-module load zlib-ng/2.1.3-clang-16.0.0-rocm5.6.0-mixed-kjg4hdy
-# openssl@=3.1.3%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-zen3
-## module load openssl/3.1.3-clang-16.0.0-rocm5.6.0-mixed-q3rmy4x
-# curl@=8.1.2%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-zen3
-module load curl/8.1.2-clang-16.0.0-rocm5.6.0-mixed-hpeeijp
-# ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-zen3
-module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-j2aesfx
-# cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen3
-module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-xcb2k24
-# blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-zen3
-module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-wcabdav
-# gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=autotools arch=linux-sles15-zen3
-module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-jtzohhr
-# hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-zen3
-module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-lvcatvl
-# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-26mgwl7
-# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,c4750bb,d35aec9 arch=linux-sles15-zen3
-module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-tydmudc
-# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-sfn2hme
-# cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-zen3
-module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-6teohk2
-# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-zen3
-module load openblas/0.3.20-gcc-12.2.0-mixed-7hydqmq
-# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-zen3
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-pdovwcj
-# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-oeelt53
-# hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-upordfk
-# magma@=2.6.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load magma/2.6.2-clang-16.0.0-rocm5.6.0-mixed-x2tryz7
-# metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
-module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-kzayikt
-# rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ulpi7by
-# raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-3t3z5vf
-# suite-sparse@=4.5.6%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic~tbb build_system=generic arch=linux-sles15-zen3
-module load suite-sparse/4.5.6-clang-16.0.0-rocm5.6.0-mixed-ercyneq
-# umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-zen3
-module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-hre5hhv
-# hiop@=0.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hiop/0.7.2-clang-16.0.0-rocm5.6.0-mixed-i6l3zkn
-# ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-zen3
-module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-5qwrkim
-# libiconv@=1.17%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load libiconv/1.17-clang-14.0.0-rocm5.2.0-mixed-ulmz25p
-# diffutils@=3.9%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load diffutils/3.9-clang-14.0.0-rocm5.2.0-mixed-scfhpum
-# python@=3.9.12%clang@=14.0.0-rocm5.2.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-zen3
-module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-xgn77vb
-# petsc@=3.19.6%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.19.6-clang-14.0.0-rocm5.2.0-mixed-7dso2zm
-# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
-## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-7zsfkec
+# pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-nqeqauq
+# nghttp2@=1.52.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load nghttp2/1.52.0-clang-16.0.0-rocm5.6.0-mixed-jwbbqw5
+# ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
+module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-b35brx3
+# perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-2nlfsvp
+# zlib-ng@=2.1.3%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools patches=299b958,ae9077a,b692621 arch=linux-sles15-x86_64
+module load zlib-ng/2.1.3-clang-16.0.0-rocm5.6.0-mixed-gnjmu6k
+# openssl@=3.1.3%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
+## module load openssl/3.1.3-clang-16.0.0-rocm5.6.0-mixed-n26v6hs
+# curl@=8.1.2%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
+module load curl/8.1.2-clang-16.0.0-rocm5.6.0-mixed-hqpytz6
+# ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
+module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-i274bqt
+# cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
+module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-zbghqwd
+# blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
+module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-ir7mjni
+# gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=autotools arch=linux-sles15-x86_64
+module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-vfbbc6y
+# hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-x86_64
+module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-d2jamhl
+# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-xwyu2nw
+# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,c4750bb,d35aec9 arch=linux-sles15-x86_64
+module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-52muhax
+# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-6ekrbkg
+# cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-x86_64
+module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-7mbfpyl
+# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
+module load openblas/0.3.20-gcc-12.2.0-mixed-3bzvwyn
+# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-x86_64
+module load coinhsl/2019.05.21-gcc-12.2.0-mixed-heq2jsz
+# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-lckx2a7
+# hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-v2eembx
+# magma@=2.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load magma/2.7.2-clang-16.0.0-rocm5.6.0-mixed-gbae2rf
+# metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
+module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-6ql7ed7
+# rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-mbf63yj
+# raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-g3pbskq
+# libiconv@=1.17%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load libiconv/1.17-clang-16.0.0-rocm5.6.0-mixed-ogrmucg
+# diffutils@=3.9%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load diffutils/3.9-clang-16.0.0-rocm5.6.0-mixed-hhpjdm4
+# libsigsegv@=2.14%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libsigsegv/2.14-clang-16.0.0-rocm5.6.0-mixed-76i7mjw
+# m4@=1.4.19%clang@=16.0.0-rocm5.6.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
+module load m4/1.4.19-clang-16.0.0-rocm5.6.0-mixed-lhit63v
+# autoconf@=2.69%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-sles15-x86_64
+module load autoconf/2.69-clang-16.0.0-rocm5.6.0-mixed-kuygqtk
+# automake@=1.16.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load automake/1.16.5-clang-16.0.0-rocm5.6.0-mixed-5b7uyw3
+# libtool@=2.4.7%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libtool/2.4.7-clang-16.0.0-rocm5.6.0-mixed-peeilj4
+# gmp@=6.2.1%clang@=16.0.0-rocm5.6.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
+module load gmp/6.2.1-clang-16.0.0-rocm5.6.0-mixed-mwflwks
+# autoconf-archive@=2023.02.20%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load autoconf-archive/2023.02.20-clang-16.0.0-rocm5.6.0-mixed-2kgjzy2
+# bzip2@=1.0.8%clang@=16.0.0-rocm5.6.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
+module load bzip2/1.0.8-clang-16.0.0-rocm5.6.0-mixed-ojn3zre
+# xz@=5.4.1%clang@=16.0.0-rocm5.6.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load xz/5.4.1-clang-16.0.0-rocm5.6.0-mixed-6q6iqds
+# libxml2@=2.10.3%clang@=16.0.0-rocm5.6.0-mixed+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
+module load libxml2/2.10.3-clang-16.0.0-rocm5.6.0-mixed-425mza3
+# pigz@=2.7%clang@=16.0.0-rocm5.6.0-mixed build_system=makefile arch=linux-sles15-x86_64
+module load pigz/2.7-clang-16.0.0-rocm5.6.0-mixed-psrpscv
+# zstd@=1.5.5%clang@=16.0.0-rocm5.6.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
+module load zstd/1.5.5-clang-16.0.0-rocm5.6.0-mixed-h6jex3o
+# tar@=1.34%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools zip=pigz arch=linux-sles15-x86_64
+module load tar/1.34-clang-16.0.0-rocm5.6.0-mixed-7qfuarw
+# gettext@=0.21.1%clang@=16.0.0-rocm5.6.0-mixed+bzip2+curses+git~libunistring+libxml2+tar+xz build_system=autotools arch=linux-sles15-x86_64
+module load gettext/0.21.1-clang-16.0.0-rocm5.6.0-mixed-45aaxj3
+# texinfo@=7.0.3%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load texinfo/7.0.3-clang-16.0.0-rocm5.6.0-mixed-j7cpx76
+# mpfr@=4.2.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load mpfr/4.2.0-clang-16.0.0-rocm5.6.0-mixed-3h7atsy
+# suite-sparse@=5.13.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
+module load suite-sparse/5.13.0-clang-16.0.0-rocm5.6.0-mixed-shcfria
+# umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
+module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-p6xcamf
+# hiop@=0.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hiop/0.7.2-clang-16.0.0-rocm5.6.0-mixed-h2koocc
+# ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
+module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-6533mqe
+# python@=3.9.12%clang@=16.0.0-rocm5.6.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-x86_64
+module load python/3.9.12-clang-16.0.0-rocm5.6.0-mixed-yd4s27l
+# petsc@=3.20.0%clang@=16.0.0-rocm5.6.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
+module load petsc/3.20.0-clang-16.0.0-rocm5.6.0-mixed-cldaweo
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-todfsla

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,109 +1,67 @@
 module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
-# pkgconf@=1.9.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load pkgconf/1.9.5-clang-14.0.0-rocm5.2.0-mixed-ywk4yys
-# nghttp2@=1.52.0%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load nghttp2/1.52.0-clang-14.0.0-rocm5.2.0-mixed-cetlhhu
-# ca-certificates-mozilla@=2023-05-30%clang@=14.0.0-rocm5.2.0-mixed build_system=generic arch=linux-sles15-zen3
-module load ca-certificates-mozilla/2023-05-30-clang-14.0.0-rocm5.2.0-mixed-q3hsdil
-# perl@=5.34.0%clang@=14.0.0-rocm5.2.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-zen3
-module load perl/5.34.0-clang-14.0.0-rocm5.2.0-mixed-a5w6vnq
-# zlib-ng@=2.1.3%clang@=14.0.0-rocm5.2.0-mixed+compat+opt build_system=autotools patches=299b958,ae9077a,b692621 arch=linux-sles15-zen3
-module load zlib-ng/2.1.3-clang-14.0.0-rocm5.2.0-mixed-ykmp64g
-# openssl@=3.1.2%clang@=14.0.0-rocm5.2.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-zen3
-## module load openssl/3.1.2-clang-14.0.0-rocm5.2.0-mixed-evjmoji
-# curl@=8.1.2%clang@=14.0.0-rocm5.2.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-zen3
-module load curl/8.1.2-clang-14.0.0-rocm5.2.0-mixed-xzheabi
-# ncurses@=6.4%clang@=14.0.0-rocm5.2.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-zen3
-module load ncurses/6.4-clang-14.0.0-rocm5.2.0-mixed-mmodrkf
-# cmake@=3.20.6%clang@=14.0.0-rocm5.2.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen3
-module load cmake/3.20.6-clang-14.0.0-rocm5.2.0-mixed-i7f6src
-# blt@=0.4.1%clang@=14.0.0-rocm5.2.0-mixed build_system=generic arch=linux-sles15-zen3
-module load blt/0.4.1-clang-14.0.0-rocm5.2.0-mixed-vuyoegu
-# gmake@=4.4.1%clang@=14.0.0-rocm5.2.0-mixed~guile build_system=autotools arch=linux-sles15-zen3
-module load gmake/4.4.1-clang-14.0.0-rocm5.2.0-mixed-x2iguqk
-# hip@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=959d1fe,c2ee21c arch=linux-sles15-zen3
-module load hip/5.2.0-clang-14.0.0-rocm5.2.0-mixed-sw5eazs
-# hsa-rocr-dev@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed+image+shared build_system=cmake build_type=Release generator=make patches=71e6851 arch=linux-sles15-zen3
-module load hsa-rocr-dev/5.2.0-clang-14.0.0-rocm5.2.0-mixed-bra7sva
-# llvm-amdgpu@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1 arch=linux-sles15-zen3
-module load llvm-amdgpu/5.2.0-clang-14.0.0-rocm5.2.0-mixed-waykj5h
-# camp@=0.2.3%clang@=14.0.0-rocm5.2.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load camp/0.2.3-clang-14.0.0-rocm5.2.0-mixed-7mrnxfz
-# cray-mpich@=8.1.25%clang@=14.0.0-rocm5.2.0-mixed+wrappers build_system=generic arch=linux-sles15-zen3
-module load cray-mpich/8.1.25-clang-14.0.0-rocm5.2.0-mixed-qd6s47h
+# pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-zen3
+module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-vp3ll6l
+# nghttp2@=1.52.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-zen3
+module load nghttp2/1.52.0-clang-16.0.0-rocm5.6.0-mixed-prks6rd
+# ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-zen3
+module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-swebvgy
+# perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-zen3
+module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-hyokfvp
+# zlib-ng@=2.1.3%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools patches=299b958,ae9077a,b692621 arch=linux-sles15-zen3
+module load zlib-ng/2.1.3-clang-16.0.0-rocm5.6.0-mixed-kjg4hdy
+# openssl@=3.1.3%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-zen3
+## module load openssl/3.1.3-clang-16.0.0-rocm5.6.0-mixed-q3rmy4x
+# curl@=8.1.2%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-zen3
+module load curl/8.1.2-clang-16.0.0-rocm5.6.0-mixed-hpeeijp
+# ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-zen3
+module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-j2aesfx
+# cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen3
+module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-xcb2k24
+# blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-zen3
+module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-wcabdav
+# gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=autotools arch=linux-sles15-zen3
+module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-jtzohhr
+# hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-zen3
+module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-lvcatvl
+# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-26mgwl7
+# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,c4750bb,d35aec9 arch=linux-sles15-zen3
+module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-tydmudc
+# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-sfn2hme
+# cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-zen3
+module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-6teohk2
 # openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-zen3
-module load openblas/0.3.20-gcc-12.2.0-mixed-qtbaxxy
+module load openblas/0.3.20-gcc-12.2.0-mixed-7hydqmq
 # coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-zen3
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-ldvspc2
-# hipblas@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipblas/5.2.0-clang-14.0.0-rocm5.2.0-mixed-qsxq2xx
-# hipfft@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipfft/5.2.0-clang-14.0.0-rocm5.2.0-mixed-pje75d4
-# hiprand@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hiprand/5.2.0-clang-14.0.0-rocm5.2.0-mixed-224knmx
-# hipsparse@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=c447537 arch=linux-sles15-zen3
-module load hipsparse/5.2.0-clang-14.0.0-rocm5.2.0-mixed-vqshjsa
-# rocprim@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocprim/5.2.0-clang-14.0.0-rocm5.2.0-mixed-6jqmhkg
-# rocrand@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed+hiprand amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=a35e689 arch=linux-sles15-zen3
-module load rocrand/5.2.0-clang-14.0.0-rocm5.2.0-mixed-nwexus7
-# rocthrust@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocthrust/5.2.0-clang-14.0.0-rocm5.2.0-mixed-3upg7wr
-# ginkgo@=1.5.0.glu_experimental%clang@=14.0.0-rocm5.2.0-mixed~cuda~develtools~full_optimizations~hwloc~ipo~mpi~oneapi~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=ba0956e arch=linux-sles15-zen3
-module load ginkgo/1.5.0.glu_experimental-clang-14.0.0-rocm5.2.0-mixed-ib5ubqb
-# magma@=2.6.2%clang@=14.0.0-rocm5.2.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load magma/2.6.2-clang-14.0.0-rocm5.2.0-mixed-mgx663z
-# metis@=5.1.0%clang@=14.0.0-rocm5.2.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
-module load metis/5.1.0-clang-14.0.0-rocm5.2.0-mixed-npre7hi
-# raja@=0.14.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~examples~exercises~ipo~openmp+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load raja/0.14.0-clang-14.0.0-rocm5.2.0-mixed-f3lha5s
+module load coinhsl/2019.05.21-gcc-12.2.0-mixed-pdovwcj
+# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-oeelt53
+# hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-upordfk
+# magma@=2.6.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load magma/2.6.2-clang-16.0.0-rocm5.6.0-mixed-x2tryz7
+# metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
+module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-kzayikt
+# rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ulpi7by
+# raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-3t3z5vf
+# suite-sparse@=4.5.6%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic~tbb build_system=generic arch=linux-sles15-zen3
+module load suite-sparse/4.5.6-clang-16.0.0-rocm5.6.0-mixed-ercyneq
+# umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-zen3
+module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-hre5hhv
+# hiop@=0.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load hiop/0.7.2-clang-16.0.0-rocm5.6.0-mixed-i6l3zkn
+# ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-zen3
+module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-5qwrkim
 # libiconv@=1.17%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load libiconv/1.17-clang-14.0.0-rocm5.2.0-mixed-s6j2luq
+module load libiconv/1.17-clang-14.0.0-rocm5.2.0-mixed-ulmz25p
 # diffutils@=3.9%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load diffutils/3.9-clang-14.0.0-rocm5.2.0-mixed-houctq3
-# libsigsegv@=2.14%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load libsigsegv/2.14-clang-14.0.0-rocm5.2.0-mixed-dq3l7q6
-# m4@=1.4.19%clang@=14.0.0-rocm5.2.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-zen3
-module load m4/1.4.19-clang-14.0.0-rocm5.2.0-mixed-xnf65bk
-# autoconf@=2.69%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-sles15-zen3
-module load autoconf/2.69-clang-14.0.0-rocm5.2.0-mixed-rbkdh7i
-# automake@=1.16.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load automake/1.16.5-clang-14.0.0-rocm5.2.0-mixed-h22kxrj
-# libtool@=2.4.7%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load libtool/2.4.7-clang-14.0.0-rocm5.2.0-mixed-yhbob3o
-# gmp@=6.2.1%clang@=14.0.0-rocm5.2.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-zen3
-module load gmp/6.2.1-clang-14.0.0-rocm5.2.0-mixed-7ddgjdu
-# autoconf-archive@=2023.02.20%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load autoconf-archive/2023.02.20-clang-14.0.0-rocm5.2.0-mixed-ctrlife
-# bzip2@=1.0.8%clang@=14.0.0-rocm5.2.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-zen3
-module load bzip2/1.0.8-clang-14.0.0-rocm5.2.0-mixed-4dwwykf
-# xz@=5.4.1%clang@=14.0.0-rocm5.2.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load xz/5.4.1-clang-14.0.0-rocm5.2.0-mixed-okiyran
-# libxml2@=2.10.3%clang@=14.0.0-rocm5.2.0-mixed~python build_system=autotools arch=linux-sles15-zen3
-module load libxml2/2.10.3-clang-14.0.0-rocm5.2.0-mixed-7ytg2jw
-# pigz@=2.7%clang@=14.0.0-rocm5.2.0-mixed build_system=makefile arch=linux-sles15-zen3
-module load pigz/2.7-clang-14.0.0-rocm5.2.0-mixed-2acdaog
-# zstd@=1.5.5%clang@=14.0.0-rocm5.2.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-zen3
-module load zstd/1.5.5-clang-14.0.0-rocm5.2.0-mixed-dct4j6t
-# tar@=1.34%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools zip=pigz arch=linux-sles15-zen3
-module load tar/1.34-clang-14.0.0-rocm5.2.0-mixed-wmbcddr
-# gettext@=0.21.1%clang@=14.0.0-rocm5.2.0-mixed+bzip2+curses+git~libunistring+libxml2+tar+xz build_system=autotools arch=linux-sles15-zen3
-module load gettext/0.21.1-clang-14.0.0-rocm5.2.0-mixed-6ymwdti
-# texinfo@=7.0.3%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load texinfo/7.0.3-clang-14.0.0-rocm5.2.0-mixed-lmssife
-# mpfr@=4.2.0%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load mpfr/4.2.0-clang-14.0.0-rocm5.2.0-mixed-lgm7ygg
-# suite-sparse@=5.13.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-zen3
-module load suite-sparse/5.13.0-clang-14.0.0-rocm5.2.0-mixed-ebugiv3
-# umpire@=6.0.0%clang@=14.0.0-rocm5.2.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-zen3
-module load umpire/6.0.0-clang-14.0.0-rocm5.2.0-mixed-cirg3w5
-# hiop@=0.7.2%clang@=14.0.0-rocm5.2.0-mixed~cuda~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel generator=make arch=linux-sles15-zen3
-module load hiop/0.7.2-clang-14.0.0-rocm5.2.0-mixed-7cjhebx
-# ipopt@=3.12.10%clang@=14.0.0-rocm5.2.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-zen3
-module load ipopt/3.12.10-clang-14.0.0-rocm5.2.0-mixed-4rq2ft7
-# python@=3.9.12%clang@=14.0.0-rocm5.2.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,f2fd060 arch=linux-sles15-zen3
-module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-izrixc2
-# petsc@=3.19.4%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.19.4-clang-14.0.0-rocm5.2.0-mixed-x2kdcas
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
-## module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-6rwuo24
+module load diffutils/3.9-clang-14.0.0-rocm5.2.0-mixed-scfhpum
+# python@=3.9.12%clang@=14.0.0-rocm5.2.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-zen3
+module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-xgn77vb
+# petsc@=3.19.6%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
+module load petsc/3.19.6-clang-14.0.0-rocm5.2.0-mixed-7dso2zm
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
+## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-7zsfkec

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,4 +1,4 @@
-module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-x86_64
 # pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
 module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-nqeqauq
 # nghttp2@=1.52.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
-module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-6rwuo24
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
+module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-7zsfkec

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
-# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/csc359/exago-frontier-amd-gfortran-github generator=make arch=linux-sles15-zen3
-module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-7zsfkec
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-todfsla

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
-module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-x86_64
 # exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt~logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
 module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-todfsla

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -98,7 +98,7 @@ spack:
     coinhsl:
       require: '@2019.05.21'
     magma:
-      require: '@2.6.2'
+      require: '@2.7.2'
     petsc:
       require: ~hypre~superlu-dist~hdf5~metis
     cray-mpich:

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - exago@develop%clang@14.0.0-rocm5.2.0-mixed amdgpu_target=gfx90a
+  - exago@develop%clang@16.0.0-rocm5.6.0-mixed amdgpu_target=gfx90a
     ^coinhsl%gcc@12.2.0-mixed
     ^openblas%gcc@12.2.0-mixed
   view: false
@@ -8,6 +8,26 @@ spack:
     unify: when_possible
     reuse: false
   compilers:
+  - compiler:
+      spec: clang@16.0.0-rocm5.6.0-mixed
+      paths:
+        cc: /opt/rocm-5.6.0/llvm/bin/amdclang
+        cxx: /opt/rocm-5.6.0/llvm/bin/amdclang++
+        f77: /opt/rocm-5.6.0/llvm/bin/amdflang
+        fc: /opt/rocm-5.6.0/llvm/bin/amdflang
+      flags: {}
+      operating_system: sles15
+      target: x86_64
+      modules:
+      - PrgEnv-gnu-amd
+      - cray-mpich/8.1.25
+      - amd-mixed/5.6.0
+      - gcc/12.2.0
+      - craype-accel-amd-gfx90a
+      - craype-x86-trento
+      - libfabric
+      environment: {}
+      extra_rpaths: []
   - compiler:
       spec: clang@14.0.0-rocm5.2.0-mixed
       paths:
@@ -41,7 +61,7 @@ spack:
       modules:
       - PrgEnv-gnu-amd
       - cray-mpich/8.1.25
-      - amd-mixed/5.2.0
+      - amd-mixed/5.6.0
       - gcc/12.2.0
       - craype-accel-amd-gfx90a
       - craype-x86-trento
@@ -51,7 +71,7 @@ spack:
   packages:
     all:
       compiler:
-      - clang@14.0.0-rocm5.2.0-mixed
+      - clang@16.0.0-rocm5.6.0-mixed
       providers:
         blas: [openblas]
         mpi: [cray-mpich]
@@ -59,7 +79,7 @@ spack:
     exago:
       require: ~python+raja+hiop+rocm+ipopt
     hiop:
-      require: +sparse+mpi+raja+rocm+ginkgo+kron
+      require: +sparse+mpi+raja+rocm~ginkgo+kron
       version: [0.7.2]
     ipopt:
       require: '@3.12.10~metis+coinhsl~mumps'
@@ -83,12 +103,12 @@ spack:
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.25 %clang@14.0.0-rocm5.2.0-mixed
+      - spec: cray-mpich@8.1.25 %clang@16.0.0-rocm5.6.0-mixed
         prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
         modules:
         - PrgEnv-gnu-amd
         - cray-mpich/8.1.25
-        - amd-mixed/5.2.0
+        - amd-mixed/5.6.0
         - gcc/12.2.0
         - craype-accel-amd-gfx90a
         - craype-x86-trento
@@ -114,163 +134,163 @@ spack:
     comgr:
       buildable: false
       externals:
-      - spec: comgr@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: comgr@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hip-rocclr:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.2.0
-        prefix: /opt/rocm-5.2.0/hip
+      - spec: hip-rocclr@5.6.0
+        prefix: /opt/rocm-5.6.0/hip
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipblas@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipcub@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipfft@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipsparse@5.6.0
+        prefix: /opt/rocm-5.6.0/
     miopen-hip:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hip-rocclr@5.6.0
+        prefix: /opt/rocm-5.6.0/
     miopengemm:
       buildable: false
       externals:
-      - spec: miopengemm@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: miopengemm@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rccl@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocblas@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocfft@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-clang-ocl:
       buildable: false
       externals:
-      - spec: rocm-clang-ocl@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-clang-ocl@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-cmake@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-dbgapi@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-debug-agent@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-device-libs@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-gdb@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@5.2.0
-        prefix: /opt/rocm-5.2.0/opencl
+      - spec: rocm-opencl@5.6.0
+        prefix: /opt/rocm-5.6.0/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-smi-lib@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hip:
       buildable: false
       externals:
-      - spec: hip@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@5.2.0
-        prefix: /opt/rocm-5.2.0/llvm
+      - spec: llvm-amdgpu@5.6.0
+        prefix: /opt/rocm-5.6.0/llvm
     hsakmt-roct:
       buildable: false
       externals:
-      - spec: hsakmt-roct@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hsakmt-roct@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hsa-rocr-dev@5.6.0
+        prefix: /opt/rocm-5.6.0/
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@5.2.0
-        prefix: /opt/rocm-5.2.0/roctracer
+      - spec: roctracer-dev-api@5.6.0
+        prefix: /opt/rocm-5.6.0/roctracer
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocprim@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocrand@5.6.0
+        prefix: /opt/rocm-5.6.0
     hiprand:
       buildable: false
       externals:
-      - spec: hiprand@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hiprand@5.6.0
+        prefix: /opt/rocm-5.6.0
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hipsolver@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocsolver@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocsparse@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocthrust@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocprofiler-dev@5.6.0
+        prefix: /opt/rocm-5.6.0
   config:
     install_tree:
       root: $SPACK_INSTALL

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -3,6 +3,7 @@ spack:
   - exago@develop%clang@16.0.0-rocm5.6.0-mixed amdgpu_target=gfx90a
     ^coinhsl%gcc@12.2.0-mixed
     ^openblas%gcc@12.2.0-mixed
+    ^petsc%clang@14.0.0-rocm5.2.0-mixed~complex
   view: false
   concretizer:
     unify: when_possible

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -3,7 +3,7 @@ spack:
   - exago@develop%clang@16.0.0-rocm5.6.0-mixed amdgpu_target=gfx90a
     ^coinhsl%gcc@12.2.0-mixed
     ^openblas%gcc@12.2.0-mixed
-    ^petsc%clang@14.0.0-rocm5.2.0-mixed~complex
+    ^petsc%clang@16.0.0-rocm5.6.0-mixed target=x86_64
   view: false
   concretizer:
     unify: when_possible

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -76,7 +76,7 @@ spack:
       providers:
         blas: [openblas]
         mpi: [cray-mpich]
-      target: [zen3]
+      target: [x86_64]
     exago:
       require: ~python+raja+hiop+rocm+ipopt
     hiop:


### PR DESCRIPTION
**Merge request type**
- [x] New feature
- [ ] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [x] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [x] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This MR updates the Spack configuration and the corresponding modules on Frontier to build with rocm/5.6.
A few notes:
- Building for `x86-64` target instead of `zen3` because of a compiler bug raised by PETSc (see #65). I opened an OLCF ticket to address this.
- Despite correctly building for x86-64, the variable $(spack arch) still returns `zen3`, so the path to the modules files was not correctly updated by default. I manually modified it, and I welcome suggestions for a sustainable solution.
- rocm/5.6 now enforces the more recent paths for header files (see https://rocm.docs.amd.com/en/docs-5.6.0/CHANGELOG.html#id31). This came up when attempting to build ExaGO in `Debug` mode against magma@2.6.2, which was using the old paths. magma@2.7.1+ implements a logic to ensure the correct paths are used depending on the ROCm version (see https://bitbucket.org/icl/magma/commits/f07ddb12ca3f3aad9253342b6800e48bd8f02888). The current build on Frontier relies on magma@2.7.2.
 
