### PR TITLE
Update spack & try petsc3.20.2

### DIFF
--- a/buildsystem/spack/ascent/modules/dependencies.sh
+++ b/buildsystem/spack/ascent/modules/dependencies.sh
@@ -15,14 +15,14 @@ module load libiconv/1.17-gcc-11.2.0-o2tcupm
 module load pkgconf/1.9.5-gcc-11.2.0-ha6twrd
 # xz@=5.4.1%gcc@=11.2.0~pic build_system=autotools libs=shared,static arch=linux-rhel8-power9le
 module load xz/5.4.1-gcc-11.2.0-auvdbvb
-# zlib-ng@=2.1.4%gcc@=11.2.0+compat+opt build_system=autotools arch=linux-rhel8-power9le
-module load zlib-ng/2.1.4-gcc-11.2.0-rhgwksf
+# zlib-ng@=2.1.5%gcc@=11.2.0+compat+opt build_system=autotools arch=linux-rhel8-power9le
+module load zlib-ng/2.1.5-gcc-11.2.0-252zisf
 # libxml2@=2.10.3%gcc@=11.2.0+pic~python+shared build_system=autotools arch=linux-rhel8-power9le
-module load libxml2/2.10.3-gcc-11.2.0-r5tqv2w
+module load libxml2/2.10.3-gcc-11.2.0-dbz64ln
 # cuda@=11.8.0%gcc@=11.2.0~allow-unsupported-compilers~dev build_system=generic arch=linux-rhel8-power9le
-module load cuda/11.8.0-gcc-11.2.0-evv4fah
+module load cuda/11.8.0-gcc-11.2.0-5ii4vhc
 # camp@=0.2.3%gcc@=11.2.0+cuda~ipo+openmp~rocm~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel8-power9le
-module load camp/0.2.3-gcc-11.2.0-dj4zwqy
+module load camp/0.2.3-gcc-11.2.0-ynp64kd
 # perl@=5.30.1%gcc@=11.2.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-rhel8-power9le
 module load perl/5.30.1-gcc-11.2.0-3hpfcbf
 # openblas@=0.3.25%gcc@=11.2.0~bignuma~consistent_fpcsr+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-rhel8-power9le
@@ -30,13 +30,13 @@ module load openblas/0.3.25-gcc-11.2.0-dyai6of
 # coinhsl@=2019.05.21%gcc@=11.2.0+blas build_system=autotools arch=linux-rhel8-power9le
 module load coinhsl/2019.05.21-gcc-11.2.0-aqbfvrh
 # ginkgo@=1.5.0.glu_experimental%gcc@=11.2.0+cuda~develtools~full_optimizations~hwloc~ipo~mpi+openmp~rocm+shared~sycl build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel8-power9le
-module load ginkgo/1.5.0.glu_experimental-gcc-11.2.0-yxxyill
+module load ginkgo/1.5.0.glu_experimental-gcc-11.2.0-peizlyh
 # magma@=2.6.2%gcc@=11.2.0+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel8-power9le
-module load magma/2.6.2-gcc-11.2.0-fb45p3p
+module load magma/2.6.2-gcc-11.2.0-wvp4mlk
 # metis@=5.1.0%gcc@=11.2.0~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903,b1225da arch=linux-rhel8-power9le
 module load metis/5.1.0-gcc-11.2.0-awo5rpq
 # raja@=0.14.0%gcc@=11.2.0+cuda~examples~exercises~ipo+openmp~plugins~rocm+shared~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-rhel8-power9le
-module load raja/0.14.0-gcc-11.2.0-cwixvss
+module load raja/0.14.0-gcc-11.2.0-aj7bcha
 # spectrum-mpi@=10.4.0.3-20210112%gcc@=11.2.0 build_system=bundle arch=linux-rhel8-power9le
 module load spectrum-mpi/10.4.0.3-20210112-gcc-11.2.0-jflmvka
 # gmp@=6.2.1%gcc@=11.2.0+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-rhel8-power9le
@@ -62,9 +62,9 @@ module load mpfr/4.2.0-gcc-11.2.0-dx7xldq
 # suite-sparse@=5.13.0%gcc@=11.2.0~cuda~graphblas~openmp+pic build_system=generic arch=linux-rhel8-power9le
 module load suite-sparse/5.13.0-gcc-11.2.0-dczi5h2
 # umpire@=6.0.0%gcc@=11.2.0+c+cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared build_system=cmake build_type=Release cuda_arch=70 generator=make tests=none arch=linux-rhel8-power9le
-module load umpire/6.0.0-gcc-11.2.0-5uaacxb
-# hiop@=develop%gcc@=11.2.0+cuda+cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/491608/hiop_dev generator=make arch=linux-rhel8-power9le
-module load hiop/develop-gcc-11.2.0-w4hozj3
+module load umpire/6.0.0-gcc-11.2.0-zptpmrx
+# hiop@=develop%gcc@=11.2.0+cuda+cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/492715/hiop_dev generator=make arch=linux-rhel8-power9le
+module load hiop/develop-gcc-11.2.0-sdx2pqq
 # ipopt@=3.12.10%gcc@=11.2.0+coinhsl~debug~metis~mumps build_system=autotools arch=linux-rhel8-power9le
 module load ipopt/3.12.10-gcc-11.2.0-5sv6zqx
 # bzip2@=1.0.8%gcc@=11.2.0~debug~pic+shared build_system=generic arch=linux-rhel8-power9le
@@ -84,7 +84,7 @@ module load gdbm/1.23-gcc-11.2.0-i5squkb
 # tar@=1.34%gcc@=11.2.0 build_system=autotools zip=pigz arch=linux-rhel8-power9le
 module load tar/1.34-gcc-11.2.0-2jrcbem
 # gettext@=0.22.4%gcc@=11.2.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-rhel8-power9le
-module load gettext/0.22.4-gcc-11.2.0-lhmpxcx
+module load gettext/0.22.4-gcc-11.2.0-5mlyppm
 # libffi@=3.4.4%gcc@=11.2.0 build_system=autotools patches=070b1f3 arch=linux-rhel8-power9le
 module load libffi/3.4.4-gcc-11.2.0-yuqvmqv
 # libxcrypt@=4.4.35%gcc@=11.2.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-rhel8-power9le
@@ -92,54 +92,54 @@ module load libxcrypt/4.4.35-gcc-11.2.0-al6z57g
 # ca-certificates-mozilla@=2023-05-30%gcc@=11.2.0 build_system=generic arch=linux-rhel8-power9le
 module load ca-certificates-mozilla/2023-05-30-gcc-11.2.0-iekj6zv
 # openssl@=3.1.3%gcc@=11.2.0~docs+shared build_system=generic certs=mozilla arch=linux-rhel8-power9le
-## module load openssl/3.1.3-gcc-11.2.0-4arro3i
+## module load openssl/3.1.3-gcc-11.2.0-mtn6km7
 # sqlite@=3.43.2%gcc@=11.2.0+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-rhel8-power9le
-module load sqlite/3.43.2-gcc-11.2.0-bnoskoo
+module load sqlite/3.43.2-gcc-11.2.0-mnsiby5
 # util-linux-uuid@=2.38.1%gcc@=11.2.0 build_system=autotools arch=linux-rhel8-power9le
 module load util-linux-uuid/2.38.1-gcc-11.2.0-h6s3b7x
 # python@=3.11.6%gcc@=11.2.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-rhel8-power9le
-module load python/3.11.6-gcc-11.2.0-3v2wn6y
-# petsc@=3.20.1%gcc@=11.2.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-rhel8-power9le
-module load petsc/3.20.1-gcc-11.2.0-ftbliji
+module load python/3.11.6-gcc-11.2.0-dfobqi6
+# petsc@=3.20.2%gcc@=11.2.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-rhel8-power9le
+module load petsc/3.20.2-gcc-11.2.0-xooggro
 # py-pip@=23.1.2%gcc@=11.2.0 build_system=generic arch=linux-rhel8-power9le
-module load py-pip/23.1.2-gcc-11.2.0-hkczsx5
+module load py-pip/23.1.2-gcc-11.2.0-sjerenw
 # py-setuptools@=68.0.0%gcc@=11.2.0 build_system=generic arch=linux-rhel8-power9le
-module load py-setuptools/68.0.0-gcc-11.2.0-uajhc3x
+module load py-setuptools/68.0.0-gcc-11.2.0-7swvrcg
 # py-wheel@=0.41.2%gcc@=11.2.0 build_system=generic arch=linux-rhel8-power9le
-module load py-wheel/0.41.2-gcc-11.2.0-qace7qm
+module load py-wheel/0.41.2-gcc-11.2.0-fsmp35a
 # py-cython@=0.29.36%gcc@=11.2.0 build_system=python_pip patches=c4369ad arch=linux-rhel8-power9le
-module load py-cython/0.29.36-gcc-11.2.0-w7bygwo
-# py-mpi4py@=3.1.4%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-mpi4py/3.1.4-gcc-11.2.0-co2il5t
+module load py-cython/0.29.36-gcc-11.2.0-cabcwpm
+# py-mpi4py@=3.1.5%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
+module load py-mpi4py/3.1.5-gcc-11.2.0-p3s6e6o
 # py-editables@=0.3%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-editables/0.3-gcc-11.2.0-3i226n4
+module load py-editables/0.3-gcc-11.2.0-wnfjn2h
 # py-flit-core@=3.9.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-flit-core/3.9.0-gcc-11.2.0-e2oyjvj
+module load py-flit-core/3.9.0-gcc-11.2.0-gzhlynr
 # py-packaging@=23.1%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-packaging/23.1-gcc-11.2.0-fyydgnz
+module load py-packaging/23.1-gcc-11.2.0-btd6dew
 # py-pathspec@=0.11.1%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-pathspec/0.11.1-gcc-11.2.0-f323v6f
+module load py-pathspec/0.11.1-gcc-11.2.0-e2wtdx7
 # git@=2.35.1%gcc@=11.2.0+man+nls+perl+subtree~svn~tcltk build_system=autotools arch=linux-rhel8-power9le
 module load git/2.35.1-gcc-11.2.0-4mw66g4
 # py-tomli@=2.0.1%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-tomli/2.0.1-gcc-11.2.0-zhokhjn
+module load py-tomli/2.0.1-gcc-11.2.0-o7htzjv
 # py-typing-extensions@=4.8.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-typing-extensions/4.8.0-gcc-11.2.0-4vegdon
+module load py-typing-extensions/4.8.0-gcc-11.2.0-llm6be4
 # py-setuptools-scm@=7.1.0%gcc@=11.2.0+toml build_system=python_pip arch=linux-rhel8-power9le
-module load py-setuptools-scm/7.1.0-gcc-11.2.0-wmshtrw
+module load py-setuptools-scm/7.1.0-gcc-11.2.0-szed3bs
 # py-pluggy@=1.0.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-pluggy/1.0.0-gcc-11.2.0-yplbi5n
+module load py-pluggy/1.0.0-gcc-11.2.0-nupo66a
 # py-calver@=2022.6.26%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-calver/2022.6.26-gcc-11.2.0-salbnyi
+module load py-calver/2022.6.26-gcc-11.2.0-7mzbzwo
 # py-trove-classifiers@=2023.8.7%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-trove-classifiers/2023.8.7-gcc-11.2.0-2ma4vwj
+module load py-trove-classifiers/2023.8.7-gcc-11.2.0-pwoc56c
 # py-hatchling@=1.18.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-hatchling/1.18.0-gcc-11.2.0-pozuunt
+module load py-hatchling/1.18.0-gcc-11.2.0-ld4cxeu
 # py-hatch-vcs@=0.3.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-hatch-vcs/0.3.0-gcc-11.2.0-k7cl5un
+module load py-hatch-vcs/0.3.0-gcc-11.2.0-s6lww4e
 # py-iniconfig@=2.0.0%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-iniconfig/2.0.0-gcc-11.2.0-d7y6m6x
+module load py-iniconfig/2.0.0-gcc-11.2.0-3vjlq4g
 # py-pytest@=7.3.2%gcc@=11.2.0 build_system=python_pip arch=linux-rhel8-power9le
-module load py-pytest/7.3.2-gcc-11.2.0-6jkx4qd
-# exago@=develop%gcc@=11.2.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/491608 generator=make arch=linux-rhel8-power9le
-## module load exago/develop-gcc-11.2.0-d64smnm
+module load py-pytest/7.3.2-gcc-11.2.0-hlhs67g
+# exago@=develop%gcc@=11.2.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/492715 generator=make arch=linux-rhel8-power9le
+## module load exago/develop-gcc-11.2.0-5sxrlgq

--- a/buildsystem/spack/ascent/modules/exago.sh
+++ b/buildsystem/spack/ascent/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /gpfs/wolf/proj-shared/csc359/exago/spack-ci/install/modules/linux-rhel8-power9le
-# exago@=develop%gcc@=11.2.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/491608 generator=make arch=linux-rhel8-power9le
-module load exago/develop-gcc-11.2.0-d64smnm
+# exago@=develop%gcc@=11.2.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=70 dev_path=/gpfs/wolf/proj-shared/csc359/ci/492715 generator=make arch=linux-rhel8-power9le
+module load exago/develop-gcc-11.2.0-5sxrlgq

--- a/buildsystem/spack/deception/modules/dependencies.sh
+++ b/buildsystem/spack/deception/modules/dependencies.sh
@@ -73,14 +73,14 @@ module load mpfr/4.2.0-gcc-9.1.0-2d5o4yj
 module load suite-sparse/5.13.0-gcc-9.1.0-aytsg72
 # umpire@=6.0.0%gcc@=9.1.0+c+cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared build_system=cmake build_type=Release cuda_arch=60,70,75,80 generator=make tests=none arch=linux-centos7-zen2
 module load umpire/6.0.0-gcc-9.1.0-zh3kabb
-# hiop@=develop%gcc@=9.1.0+cuda~cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=MinSizeRel cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26233/spack_deception/hiop_dev generator=make arch=linux-centos7-zen2
-module load hiop/develop-gcc-9.1.0-kllcazs
+# hiop@=develop%gcc@=9.1.0+cuda~cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=MinSizeRel cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26535/spack_deception/hiop_dev generator=make arch=linux-centos7-zen2
+module load hiop/develop-gcc-9.1.0-v5bgi52
 # ipopt@=3.12.10%gcc@=9.1.0+coinhsl~debug~metis~mumps build_system=autotools arch=linux-centos7-zen2
 module load ipopt/3.12.10-gcc-9.1.0-li7gpqb
 # python@=3.9.12%gcc@=9.1.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-centos7-zen2
 module load python/3.9.12-gcc-9.1.0-a5w6cuq
-# petsc@=3.20.1%gcc@=9.1.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos7-zen2
-module load petsc/3.20.1-gcc-9.1.0-llz33ok
+# petsc@=3.20.2%gcc@=9.1.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos7-zen2
+module load petsc/3.20.2-gcc-9.1.0-orrankw
 # py-pip@=23.1.2%gcc@=9.1.0 build_system=generic arch=linux-centos7-zen2
 module load py-pip/23.1.2-gcc-9.1.0-pvy73ms
 # py-setuptools@=68.0.0%gcc@=9.1.0 build_system=generic arch=linux-centos7-zen2
@@ -89,8 +89,8 @@ module load py-setuptools/68.0.0-gcc-9.1.0-fef5ebz
 module load py-wheel/0.41.2-gcc-9.1.0-ycwjnxk
 # py-cython@=0.29.36%gcc@=9.1.0 build_system=python_pip patches=c4369ad arch=linux-centos7-zen2
 module load py-cython/0.29.36-gcc-9.1.0-lhxhitm
-# py-mpi4py@=3.1.4%gcc@=9.1.0 build_system=python_pip arch=linux-centos7-zen2
-module load py-mpi4py/3.1.4-gcc-9.1.0-y5dj2ru
+# py-mpi4py@=3.1.5%gcc@=9.1.0 build_system=python_pip arch=linux-centos7-zen2
+module load py-mpi4py/3.1.5-gcc-9.1.0-7xg3hnu
 # py-flit-core@=3.9.0%gcc@=9.1.0 build_system=python_pip arch=linux-centos7-zen2
 module load py-flit-core/3.9.0-gcc-9.1.0-tgih3ig
 # git@=2.37.3%gcc@=9.1.0+man+nls+perl+subtree~svn~tcltk build_system=autotools arch=linux-centos7-zen2
@@ -125,5 +125,5 @@ module load py-hatch-vcs/0.3.0-gcc-9.1.0-hwwyqic
 module load py-iniconfig/2.0.0-gcc-9.1.0-raa2jbg
 # py-pytest@=7.3.2%gcc@=9.1.0 build_system=python_pip arch=linux-centos7-zen2
 module load py-pytest/7.3.2-gcc-9.1.0-2nh22mh
-# exago@=develop%gcc@=9.1.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26233/spack_deception generator=make arch=linux-centos7-zen2
-## module load exago/develop-gcc-9.1.0-27tyuch
+# exago@=develop%gcc@=9.1.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26535/spack_deception generator=make arch=linux-centos7-zen2
+## module load exago/develop-gcc-9.1.0-tk4zxrz

--- a/buildsystem/spack/deception/modules/exago.sh
+++ b/buildsystem/spack/deception/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /qfs/projects/exasgd/src/deception-ci/install/ci-modules/linux-centos7-zen2
-# exago@=develop%gcc@=9.1.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26233/spack_deception generator=make arch=linux-centos7-zen2
-module load exago/develop-gcc-9.1.0-27tyuch
+# exago@=develop%gcc@=9.1.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=60,70,75,80 dev_path=/people/svcexasgd/gitlab/26535/spack_deception generator=make arch=linux-centos7-zen2
+module load exago/develop-gcc-9.1.0-tk4zxrz

--- a/buildsystem/spack/incline/modules/dependencies.sh
+++ b/buildsystem/spack/incline/modules/dependencies.sh
@@ -9,18 +9,18 @@ module load nghttp2/1.57.0-clang-15.0.0-rocm5.3.0-fik2ce4
 module load ca-certificates-mozilla/2023-05-30-clang-15.0.0-rocm5.3.0-3h22nit
 # perl@=5.26.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +cpanm+opcode+open+shared+threads build_system=generic patches=0eac10e,8cf4302 arch=linux-centos7-zen
 module load perl/5.26.0-clang-15.0.0-rocm5.3.0-caldjac
-# zlib-ng@=2.1.4%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +compat+opt build_system=autotools arch=linux-centos7-zen
-module load zlib-ng/2.1.4-clang-15.0.0-rocm5.3.0-thdjgv4
+# zlib-ng@=2.1.5%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +compat+opt build_system=autotools arch=linux-centos7-zen
+module load zlib-ng/2.1.5-clang-15.0.0-rocm5.3.0-526o4rf
 # openssl@=3.1.3%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~docs+shared build_system=generic certs=mozilla arch=linux-centos7-zen
-## module load openssl/3.1.3-clang-15.0.0-rocm5.3.0-52sxo3k
+## module load openssl/3.1.3-clang-15.0.0-rocm5.3.0-i7yqqwi
 # curl@=8.4.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-centos7-zen
-module load curl/8.4.0-clang-15.0.0-rocm5.3.0-xzecafv
+module load curl/8.4.0-clang-15.0.0-rocm5.3.0-jsvdhcc
 # ncurses@=6.4%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~symlinks+termlib abi=none build_system=autotools arch=linux-centos7-zen
 module load ncurses/6.4-clang-15.0.0-rocm5.3.0-w7n6gfi
 # cmake@=3.20.6%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-centos7-zen
-module load cmake/3.20.6-clang-15.0.0-rocm5.3.0-msj3iyw
+module load cmake/3.20.6-clang-15.0.0-rocm5.3.0-o42dvyt
 # blt@=0.4.1%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=generic arch=linux-centos7-zen
-module load blt/0.4.1-clang-15.0.0-rocm5.3.0-si5yj4g
+module load blt/0.4.1-clang-15.0.0-rocm5.3.0-ghyk7hz
 # hip@=5.3.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+rocm build_system=cmake build_type=Release generator=make patches=c2ee21c,ca523f1 arch=linux-centos7-zen
 module load hip/5.3.0-clang-15.0.0-rocm5.3.0-h2m6ftv
 # hsa-rocr-dev@=5.3.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-centos7-zen
@@ -28,7 +28,7 @@ module load hsa-rocr-dev/5.3.0-clang-15.0.0-rocm5.3.0-6u5zxpw
 # llvm-amdgpu@=5.3.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1 arch=linux-centos7-zen
 module load llvm-amdgpu/5.3.0-clang-15.0.0-rocm5.3.0-yggd56o
 # camp@=0.2.3%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx908 build_system=cmake build_type=Release generator=make arch=linux-centos7-zen
-module load camp/0.2.3-clang-15.0.0-rocm5.3.0-ror2y2y
+module load camp/0.2.3-clang-15.0.0-rocm5.3.0-lukemzi
 # gmake@=4.4.1%gcc@=8.4.0~guile build_system=generic arch=linux-centos7-zen
 module load gmake/4.4.1-gcc-8.4.0-4fgniv2
 # openblas@=0.3.20%gcc@=8.4.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-centos7-zen
@@ -40,15 +40,15 @@ module load hipblas/5.3.0-clang-15.0.0-rocm5.3.0-zwlmr5u
 # hipsparse@=5.3.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=c447537 arch=linux-centos7-zen
 module load hipsparse/5.3.0-clang-15.0.0-rocm5.3.0-ngj46ki
 # magma@=2.6.2%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx908 build_system=cmake build_type=Release generator=make arch=linux-centos7-zen
-module load magma/2.6.2-clang-15.0.0-rocm5.3.0-af5e7a6
+module load magma/2.6.2-clang-15.0.0-rocm5.3.0-zc53wqt
 # metis@=5.1.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-centos7-zen
-module load metis/5.1.0-clang-15.0.0-rocm5.3.0-vntgtjm
+module load metis/5.1.0-clang-15.0.0-rocm5.3.0-4vgjgia
 # openmpi@=4.1.4%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-pmix~java~legacylaunchers~lustre~memchecker~openshmem~orterunprefix+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none schedulers=none arch=linux-centos7-zen
 module load openmpi/4.1.4-clang-15.0.0-rocm5.3.0-2ry77mh
 # rocprim@=5.3.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=98506fb arch=linux-centos7-zen
 module load rocprim/5.3.0-clang-15.0.0-rocm5.3.0-z5i2hbr
 # raja@=0.14.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx908 build_system=cmake build_type=Release generator=make arch=linux-centos7-zen
-module load raja/0.14.0-clang-15.0.0-rocm5.3.0-mypjo5k
+module load raja/0.14.0-clang-15.0.0-rocm5.3.0-mubleoh
 # libiconv@=1.17%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=autotools libs=shared,static arch=linux-centos7-zen
 module load libiconv/1.17-clang-15.0.0-rocm5.3.0-anlnmwt
 # diffutils@=3.9%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=autotools arch=linux-centos7-zen
@@ -72,30 +72,30 @@ module load bzip2/1.0.8-clang-15.0.0-rocm5.3.0-l3whoev
 # xz@=5.4.1%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~pic build_system=autotools libs=shared,static arch=linux-centos7-zen
 module load xz/5.4.1-clang-15.0.0-rocm5.3.0-mvnfwal
 # libxml2@=2.10.3%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +pic~python+shared build_system=autotools arch=linux-centos7-zen
-module load libxml2/2.10.3-clang-15.0.0-rocm5.3.0-nsspgz4
+module load libxml2/2.10.3-clang-15.0.0-rocm5.3.0-3yavliv
 # pigz@=2.7%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=makefile arch=linux-centos7-zen
-module load pigz/2.7-clang-15.0.0-rocm5.3.0-d2x7neu
+module load pigz/2.7-clang-15.0.0-rocm5.3.0-w6hqfb7
 # zstd@=1.5.5%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +programs build_system=makefile compression=none libs=shared,static arch=linux-centos7-zen
 module load zstd/1.5.5-clang-15.0.0-rocm5.3.0-5mdcukt
 # tar@=1.34%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=autotools zip=pigz arch=linux-centos7-zen
-module load tar/1.34-clang-15.0.0-rocm5.3.0-soq5gz3
+module load tar/1.34-clang-15.0.0-rocm5.3.0-wrpvflu
 # gettext@=0.22.4%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-centos7-zen
-module load gettext/0.22.4-clang-15.0.0-rocm5.3.0-r7y5i4b
+module load gettext/0.22.4-clang-15.0.0-rocm5.3.0-cb5rwnh
 # texinfo@=7.0.3%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=autotools arch=linux-centos7-zen
-module load texinfo/7.0.3-clang-15.0.0-rocm5.3.0-n7m7wdr
+module load texinfo/7.0.3-clang-15.0.0-rocm5.3.0-khbvgj6
 # mpfr@=4.2.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/"  build_system=autotools libs=shared,static arch=linux-centos7-zen
-module load mpfr/4.2.0-clang-15.0.0-rocm5.3.0-ggajnde
+module load mpfr/4.2.0-clang-15.0.0-rocm5.3.0-sg4eb4y
 # suite-sparse@=5.13.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda~graphblas~openmp+pic build_system=generic arch=linux-centos7-zen
-module load suite-sparse/5.13.0-clang-15.0.0-rocm5.3.0-c4mkzlr
+module load suite-sparse/5.13.0-clang-15.0.0-rocm5.3.0-e2gf3ub
 # umpire@=6.0.0%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx908 build_system=cmake build_type=Release generator=make tests=none arch=linux-centos7-zen
-module load umpire/6.0.0-clang-15.0.0-rocm5.3.0-pffsqxh
-# hiop@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26335/spack_incline/hiop_dev generator=make arch=linux-centos7-zen
-module load hiop/develop-clang-15.0.0-rocm5.3.0-bxpd7si
+module load umpire/6.0.0-clang-15.0.0-rocm5.3.0-jlfcdqu
+# hiop@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26536/spack_incline/hiop_dev generator=make arch=linux-centos7-zen
+module load hiop/develop-clang-15.0.0-rocm5.3.0-rpx6cfv
 # ipopt@=3.12.10%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +coinhsl~debug~metis~mumps build_system=autotools arch=linux-centos7-zen
 module load ipopt/3.12.10-clang-15.0.0-rocm5.3.0-fyusbut
 # python@=3.11.4%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" +bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-centos7-zen
 module load python/3.11.4-clang-15.0.0-rocm5.3.0-bjornb6
 # petsc@=3.20.1%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos7-zen
 module load petsc/3.20.1-clang-15.0.0-rocm5.3.0-qwd245y
-# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26335/spack_incline generator=make arch=linux-centos7-zen
-## module load exago/develop-clang-15.0.0-rocm5.3.0-q3rr7b7
+# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26536/spack_incline generator=make arch=linux-centos7-zen
+## module load exago/develop-clang-15.0.0-rocm5.3.0-pnku3g5

--- a/buildsystem/spack/incline/modules/exago.sh
+++ b/buildsystem/spack/incline/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /qfs/projects/exasgd/src/ci-incline/install/modules/linux-centos7-zen
-# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26335/spack_incline generator=make arch=linux-centos7-zen
-module load exago/develop-clang-15.0.0-rocm5.3.0-q3rr7b7
+# exago@=develop%clang@=15.0.0-rocm5.3.0 cxxflags="--gcc-toolchain=/share/apps/gcc/8.4.0/" ~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx908 build_system=cmake build_type=Release dev_path=/people/svcexasgd/gitlab/26536/spack_incline generator=make arch=linux-centos7-zen
+module load exago/develop-clang-15.0.0-rocm5.3.0-pnku3g5

--- a/buildsystem/spack/newell/modules/dependencies.sh
+++ b/buildsystem/spack/newell/modules/dependencies.sh
@@ -23,80 +23,80 @@ module load ncurses/6.4-gcc-8.5.0-t7cgvnx
 module load readline/8.2-gcc-8.5.0-ekbdswm
 # gdbm@=1.23%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load gdbm/1.23-gcc-8.5.0-bnlfqr7
-# zlib-ng@=2.1.4%gcc@=8.5.0+compat+opt build_system=autotools arch=linux-centos8-power9le
-module load zlib-ng/2.1.4-gcc-8.5.0-w7n6mdy
+# zlib-ng@=2.1.5%gcc@=8.5.0+compat+opt build_system=autotools arch=linux-centos8-power9le
+module load zlib-ng/2.1.5-gcc-8.5.0-jyxv2iy
 # perl@=5.38.0%gcc@=8.5.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-centos8-power9le
-module load perl/5.38.0-gcc-8.5.0-2r4twvm
+module load perl/5.38.0-gcc-8.5.0-cdd5hba
 # openssl@=3.1.3%gcc@=8.5.0~docs+shared build_system=generic certs=mozilla arch=linux-centos8-power9le
-## module load openssl/3.1.3-gcc-8.5.0-slvshxg
+## module load openssl/3.1.3-gcc-8.5.0-jzdyuhc
 # curl@=8.4.0%gcc@=8.5.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-centos8-power9le
-module load curl/8.4.0-gcc-8.5.0-fj3pe3l
-# cmake@=3.27.7%gcc@=8.5.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-centos8-power9le
-module load cmake/3.27.7-gcc-8.5.0-3xxpipf
+module load curl/8.4.0-gcc-8.5.0-joezlaf
+# cmake@=3.27.9%gcc@=8.5.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-centos8-power9le
+module load cmake/3.27.9-gcc-8.5.0-zjwelyo
 # blt@=0.4.1%gcc@=8.5.0 build_system=generic arch=linux-centos8-power9le
-module load blt/0.4.1-gcc-8.5.0-yadj2vt
+module load blt/0.4.1-gcc-8.5.0-zux4xxc
 # cub@=2.1.0%gcc@=8.5.0 build_system=generic arch=linux-centos8-power9le
 module load cub/2.1.0-gcc-8.5.0-lx5hjs2
 # cuda@=11.4%gcc@=8.5.0~allow-unsupported-compilers~dev build_system=generic arch=linux-centos8-power9le
-module load cuda/11.4-gcc-8.5.0-kh4c7o4
+module load cuda/11.4-gcc-8.5.0-fcxmvvd
 # camp@=0.2.3%gcc@=8.5.0+cuda~ipo+openmp~rocm~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-centos8-power9le
-module load camp/0.2.3-gcc-8.5.0-z42wdnn
+module load camp/0.2.3-gcc-8.5.0-wqt335s
 # openblas@=0.3.25%gcc@=8.5.0~bignuma~consistent_fpcsr+fortran~ilp64+locking+pic+shared build_system=makefile symbol_suffix=none threads=none arch=linux-centos8-power9le
-module load openblas/0.3.25-gcc-8.5.0-wokmlm3
+module load openblas/0.3.25-gcc-8.5.0-zoyafht
 # coinhsl@=2019.05.21%gcc@=8.5.0+blas build_system=autotools arch=linux-centos8-power9le
-module load coinhsl/2019.05.21-gcc-8.5.0-z5bfsep
+module load coinhsl/2019.05.21-gcc-8.5.0-6ms33wi
 # ginkgo@=1.5.0.glu_experimental%gcc@=8.5.0+cuda~develtools~full_optimizations~hwloc~ipo~mpi+openmp~rocm+shared~sycl build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-centos8-power9le
-module load ginkgo/1.5.0.glu_experimental-gcc-8.5.0-to767fj
+module load ginkgo/1.5.0.glu_experimental-gcc-8.5.0-a7bgjim
 # magma@=2.6.2%gcc@=8.5.0+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-centos8-power9le
-module load magma/2.6.2-gcc-8.5.0-o7f67se
+module load magma/2.6.2-gcc-8.5.0-wflxvhq
 # metis@=5.1.0%gcc@=8.5.0~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903,b1225da arch=linux-centos8-power9le
-module load metis/5.1.0-gcc-8.5.0-qmqpgih
+module load metis/5.1.0-gcc-8.5.0-e67gfid
 # openmpi@=4.1.4%gcc@=8.5.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-pmix~java~legacylaunchers~lustre~memchecker~openshmem~orterunprefix+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none schedulers=none arch=linux-centos8-power9le
 module load openmpi/4.1.4-gcc-8.5.0-b4va3xy
 # raja@=0.14.0%gcc@=8.5.0+cuda~examples~exercises~ipo+openmp~plugins~rocm+shared~tests build_system=cmake build_type=Release cuda_arch=70 generator=make arch=linux-centos8-power9le
-module load raja/0.14.0-gcc-8.5.0-akyygh5
+module load raja/0.14.0-gcc-8.5.0-yntvr74
 # libsigsegv@=2.14%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load libsigsegv/2.14-gcc-8.5.0-2igjfex
 # m4@=1.4.19%gcc@=8.5.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-centos8-power9le
 module load m4/1.4.19-gcc-8.5.0-zmwmrjj
 # autoconf@=2.69%gcc@=8.5.0 build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-centos8-power9le
-module load autoconf/2.69-gcc-8.5.0-qss6fq3
+module load autoconf/2.69-gcc-8.5.0-oxht7ld
 # automake@=1.16.5%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
-module load automake/1.16.5-gcc-8.5.0-5ak4ma2
+module load automake/1.16.5-gcc-8.5.0-iv4yes2
 # libtool@=2.4.7%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load libtool/2.4.7-gcc-8.5.0-el3zfel
 # gmp@=6.2.1%gcc@=8.5.0+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-centos8-power9le
-module load gmp/6.2.1-gcc-8.5.0-shj27b4
+module load gmp/6.2.1-gcc-8.5.0-mexqehb
 # autoconf-archive@=2023.02.20%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load autoconf-archive/2023.02.20-gcc-8.5.0-h3vkl44
 # xz@=5.4.1%gcc@=8.5.0~pic build_system=autotools libs=shared,static arch=linux-centos8-power9le
 module load xz/5.4.1-gcc-8.5.0-4k2rc3w
 # libxml2@=2.10.3%gcc@=8.5.0+pic~python+shared build_system=autotools arch=linux-centos8-power9le
-module load libxml2/2.10.3-gcc-8.5.0-wighgm3
+module load libxml2/2.10.3-gcc-8.5.0-fee6mnd
 # pigz@=2.7%gcc@=8.5.0 build_system=makefile arch=linux-centos8-power9le
-module load pigz/2.7-gcc-8.5.0-272vqg3
+module load pigz/2.7-gcc-8.5.0-mmlvzjd
 # zstd@=1.5.5%gcc@=8.5.0+programs build_system=makefile compression=none libs=shared,static arch=linux-centos8-power9le
 module load zstd/1.5.5-gcc-8.5.0-p52n5sn
 # tar@=1.34%gcc@=8.5.0 build_system=autotools zip=pigz arch=linux-centos8-power9le
-module load tar/1.34-gcc-8.5.0-dt37vzs
+module load tar/1.34-gcc-8.5.0-fuqnfzk
 # gettext@=0.22.4%gcc@=8.5.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-centos8-power9le
-module load gettext/0.22.4-gcc-8.5.0-abrp5rm
+module load gettext/0.22.4-gcc-8.5.0-mpisnwr
 # texinfo@=7.0.3%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
-module load texinfo/7.0.3-gcc-8.5.0-wimw3l7
+module load texinfo/7.0.3-gcc-8.5.0-w6m4l4d
 # mpfr@=4.2.0%gcc@=8.5.0 build_system=autotools libs=shared,static arch=linux-centos8-power9le
-module load mpfr/4.2.0-gcc-8.5.0-zts65hz
+module load mpfr/4.2.0-gcc-8.5.0-badscyk
 # suite-sparse@=5.13.0%gcc@=8.5.0~cuda~graphblas~openmp+pic build_system=generic arch=linux-centos8-power9le
-module load suite-sparse/5.13.0-gcc-8.5.0-yzt7mdy
+module load suite-sparse/5.13.0-gcc-8.5.0-btjz7ko
 # umpire@=6.0.0%gcc@=8.5.0+c+cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp~rocm~shared build_system=cmake build_type=Release cuda_arch=70 generator=make tests=none arch=linux-centos8-power9le
-module load umpire/6.0.0-gcc-8.5.0-3hm2whr
-# hiop@=develop%gcc@=8.5.0+cuda~cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=Debug cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26190/spack_newell/hiop_dev generator=make arch=linux-centos8-power9le
-module load hiop/develop-gcc-8.5.0-7ck7er5
+module load umpire/6.0.0-gcc-8.5.0-cu4ij4z
+# hiop@=develop%gcc@=8.5.0+cuda~cusolver_lu~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja~rocm~shared+sparse build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26534/spack_newell/hiop_dev generator=make arch=linux-centos8-power9le
+module load hiop/develop-gcc-8.5.0-23kohcb
 # ipopt@=3.12.10%gcc@=8.5.0+coinhsl~debug~metis~mumps build_system=autotools arch=linux-centos8-power9le
-module load ipopt/3.12.10-gcc-8.5.0-rucines
+module load ipopt/3.12.10-gcc-8.5.0-qe5oe6x
 # python@=3.8.5%gcc@=8.5.0+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-centos8-power9le
 module load python/3.8.5-gcc-8.5.0-dwf3kgs
-# petsc@=3.20.1%gcc@=8.5.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos8-power9le
-module load petsc/3.20.1-gcc-8.5.0-6wcyj55
+# petsc@=3.20.2%gcc@=8.5.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-centos8-power9le
+module load petsc/3.20.2-gcc-8.5.0-3hyboap
 # py-pip@=23.1.2%gcc@=8.5.0 build_system=generic arch=linux-centos8-power9le
 module load py-pip/23.1.2-gcc-8.5.0-45skzep
 # py-setuptools@=68.0.0%gcc@=8.5.0 build_system=generic arch=linux-centos8-power9le
@@ -105,8 +105,8 @@ module load py-setuptools/68.0.0-gcc-8.5.0-be735hh
 module load py-wheel/0.41.2-gcc-8.5.0-o5hqddm
 # py-cython@=0.29.36%gcc@=8.5.0 build_system=python_pip patches=c4369ad arch=linux-centos8-power9le
 module load py-cython/0.29.36-gcc-8.5.0-4lthysc
-# py-mpi4py@=3.1.4%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-mpi4py/3.1.4-gcc-8.5.0-aaxbl2w
+# py-mpi4py@=3.1.5%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
+module load py-mpi4py/3.1.5-gcc-8.5.0-dlyvoe2
 # py-flit-core@=3.9.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-flit-core/3.9.0-gcc-8.5.0-7qlf3hc
 # libmd@=1.0.4%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
@@ -120,21 +120,21 @@ module load libunistring/1.1-gcc-8.5.0-y3gjdbv
 # libidn2@=2.3.4%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load libidn2/2.3.4-gcc-8.5.0-seplt7v
 # bison@=3.8.2%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
-module load bison/3.8.2-gcc-8.5.0-p53xq7y
+module load bison/3.8.2-gcc-8.5.0-752euud
 # findutils@=4.9.0%gcc@=8.5.0 build_system=autotools patches=440b954 arch=linux-centos8-power9le
 module load findutils/4.9.0-gcc-8.5.0-j6yj47y
 # krb5@=1.20.1%gcc@=8.5.0+shared build_system=autotools arch=linux-centos8-power9le
-module load krb5/1.20.1-gcc-8.5.0-lqo7ggz
+module load krb5/1.20.1-gcc-8.5.0-q23rsxg
 # libedit@=3.1-20210216%gcc@=8.5.0 build_system=autotools arch=linux-centos8-power9le
 module load libedit/3.1-20210216-gcc-8.5.0-xz3heyj
 # libxcrypt@=4.4.35%gcc@=8.5.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-centos8-power9le
-module load libxcrypt/4.4.35-gcc-8.5.0-nnuqrig
+module load libxcrypt/4.4.35-gcc-8.5.0-mdczuqr
 # openssh@=9.5p1%gcc@=8.5.0+gssapi build_system=autotools arch=linux-centos8-power9le
-module load openssh/9.5p1-gcc-8.5.0-rq4fwuu
+module load openssh/9.5p1-gcc-8.5.0-o7j6ws6
 # pcre2@=10.42%gcc@=8.5.0~jit+multibyte build_system=autotools arch=linux-centos8-power9le
 module load pcre2/10.42-gcc-8.5.0-lvf7rst
 # git@=2.42.0%gcc@=8.5.0+man+nls+perl+subtree~svn~tcltk build_system=autotools arch=linux-centos8-power9le
-module load git/2.42.0-gcc-8.5.0-b5ddzfl
+module load git/2.42.0-gcc-8.5.0-kxc64wp
 # py-packaging@=23.1%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-packaging/23.1-gcc-8.5.0-fupho4o
 # py-tomli@=2.0.1%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
@@ -142,28 +142,28 @@ module load py-tomli/2.0.1-gcc-8.5.0-a4g62fz
 # py-typing-extensions@=4.8.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-typing-extensions/4.8.0-gcc-8.5.0-usi6lq5
 # py-setuptools-scm@=7.1.0%gcc@=8.5.0+toml build_system=python_pip arch=linux-centos8-power9le
-module load py-setuptools-scm/7.1.0-gcc-8.5.0-u7dcrps
+module load py-setuptools-scm/7.1.0-gcc-8.5.0-awwmkj3
 # py-flit-scm@=1.7.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-flit-scm/1.7.0-gcc-8.5.0-ov6nqzs
+module load py-flit-scm/1.7.0-gcc-8.5.0-oc4d4zd
 # py-exceptiongroup@=1.1.1%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-exceptiongroup/1.1.1-gcc-8.5.0-uk34au2
+module load py-exceptiongroup/1.1.1-gcc-8.5.0-u4zhjo2
 # py-editables@=0.3%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-editables/0.3-gcc-8.5.0-dcmsfjz
 # py-pathspec@=0.11.1%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-pathspec/0.11.1-gcc-8.5.0-7xbvbhg
 # py-pluggy@=1.0.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-pluggy/1.0.0-gcc-8.5.0-wlbjopm
+module load py-pluggy/1.0.0-gcc-8.5.0-7tvvt3m
 # py-calver@=2022.6.26%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-calver/2022.6.26-gcc-8.5.0-hgxbsu2
 # py-trove-classifiers@=2023.8.7%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
 module load py-trove-classifiers/2023.8.7-gcc-8.5.0-5wwsb65
 # py-hatchling@=1.18.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-hatchling/1.18.0-gcc-8.5.0-agn6can
+module load py-hatchling/1.18.0-gcc-8.5.0-m7vyucy
 # py-hatch-vcs@=0.3.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-hatch-vcs/0.3.0-gcc-8.5.0-aiflljq
+module load py-hatch-vcs/0.3.0-gcc-8.5.0-etimeuw
 # py-iniconfig@=2.0.0%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-iniconfig/2.0.0-gcc-8.5.0-f45q4wi
+module load py-iniconfig/2.0.0-gcc-8.5.0-n4k4cbt
 # py-pytest@=7.3.2%gcc@=8.5.0 build_system=python_pip arch=linux-centos8-power9le
-module load py-pytest/7.3.2-gcc-8.5.0-fnzfnsk
-# exago@=develop%gcc@=8.5.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26190/spack_newell generator=make arch=linux-centos8-power9le
-## module load exago/develop-gcc-8.5.0-ypyriqf
+module load py-pytest/7.3.2-gcc-8.5.0-aprjpiw
+# exago@=develop%gcc@=8.5.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26534/spack_newell generator=make arch=linux-centos8-power9le
+## module load exago/develop-gcc-8.5.0-frqiwyf

--- a/buildsystem/spack/newell/modules/exago.sh
+++ b/buildsystem/spack/newell/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /qfs/projects/exasgd/src/ci-newll/spack-install/ci-modules/linux-centos8-power9le
-# exago@=develop%gcc@=8.5.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=Debug cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26190/spack_newell generator=make arch=linux-centos8-power9le
-module load exago/develop-gcc-8.5.0-ypyriqf
+# exago@=develop%gcc@=8.5.0+cuda+hiop~ipo+ipopt+logging+mpi+python+raja~rocm build_system=cmake build_type=MinSizeRel cuda_arch=70 dev_path=/people/svcexasgd/gitlab/26534/spack_newell generator=make arch=linux-centos8-power9le
+module load exago/develop-gcc-8.5.0-frqiwyf


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [X] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [X] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [X] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

From #84 the spack submodule was using my (@jaelynlitz's) fork of spack. This resets the submodule to the spack repo now that [the fork PR](https://github.com/spack/spack/pull/41384) is merged.

