### PR TITLE
Modified is_true_somewhere function to use integers instead of bools.…

### DIFF
--- a/tests/functionality/toml_utils.h
+++ b/tests/functionality/toml_utils.h
@@ -69,11 +69,14 @@ void fmt_comment(std::ostream &summary, int col_width, std::string key,
 }
 
 bool is_true_somewhere(bool flag, MPI_Comm comm) {
+  int in, out;
   bool ret;
-  int err = MPI_Allreduce(&flag, &ret, 1, MPI_CXX_BOOL, MPI_LOR, comm);
+  flag ? in = 1 : in = 0;
+  int err = MPI_Allreduce(&in, &out, 1, MPI_INT, MPI_SUM, comm);
   if (err != MPI_SUCCESS) {
     throw ExaGOError("Error in is_true_somewhere for MPI_Allreduce");
   }
+  out == 0 ? ret = false : ret = true;
   return ret;
 }
 


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**
Modifies the implementation of the the is_true_somewhere function to use integers instead of bools. This should get around some implementation issues that affect the build on Frontier.

**Linked Issue(s)**
- Workaround for #100 
