### PR TITLE
Remove CPU time from OPFLOW output

### DIFF
--- a/include/private/opflowimpl.h
+++ b/include/private/opflowimpl.h
@@ -299,7 +299,6 @@ struct _p_OPFLOW {
 
   /** @brief OPFLOWSolve time */
   PetscLogDouble solve_real_time;
-  PetscLogDouble solve_cpu_time;
 
   /** @brief number of nonzeros used with HiOP MDS */
   PetscInt nnz_eqjacsp, nnz_ineqjacsp, nnz_hesssp;

--- a/include/private/psimpl.h
+++ b/include/private/psimpl.h
@@ -456,7 +456,6 @@ struct _p_PS {
   PetscBool setupcalled; /* Is setup called on PS? */
 
   PetscLogDouble solve_real_time;
-  PetscLogDouble solve_cpu_time;
 };
 
 extern PetscErrorCode PSCheckTopology(PS);

--- a/src/opflow/interface/opflow.cpp
+++ b/src/opflow/interface/opflow.cpp
@@ -1901,7 +1901,6 @@ PetscErrorCode OPFLOWSetUp(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   opflow->solve_real_time = 0.0;
-  opflow->solve_cpu_time = 0.0;
 
   /* Compute area participation factors */
   ierr = PSComputeParticipationFactors(ps);
@@ -2029,7 +2028,6 @@ PetscErrorCode OPFLOWSolve(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   opflow->solve_real_time = real2 - real1;
-  opflow->solve_cpu_time = cpu2 - cpu1;
 
   PetscFunctionReturn(0);
 }
@@ -2987,7 +2985,6 @@ PetscErrorCode OPFLOWSetSummaryStats(OPFLOW opflow) {
   CHKERRQ(ierr);
 
   ps->solve_real_time = opflow->solve_real_time;
-  ps->solve_cpu_time = opflow->solve_cpu_time;
 
   PetscFunctionReturn(0);
 }

--- a/src/ps/ps.cpp
+++ b/src/ps/ps.cpp
@@ -795,7 +795,6 @@ PetscErrorCode PSCreate(MPI_Comm mpicomm, PS *psout) {
   ps->setupcalled = PETSC_FALSE;
 
   ps->solve_real_time = 0.0;
-  ps->solve_cpu_time = 0.0;
 
   *psout = ps;
   PetscFunctionReturn(0);

--- a/src/ps/psoutput.cpp
+++ b/src/ps/psoutput.cpp
@@ -271,7 +271,6 @@ PetscErrorCode PSSaveSolution_MATPOWER(PS ps, const char outfile[]) {
 
   fprintf(fd, "\n%%%% solve time\n");
   fprintf(fd, "%ssolve_time = %.5g;\n", prefix, ps->solve_real_time);
-  fprintf(fd, "%ssolve_cpu_time = %.5g;\n", prefix, ps->solve_cpu_time);
 
   fclose(fd);
   PetscFunctionReturn(0);
@@ -831,7 +830,6 @@ PetscErrorCode PSSaveSolution_JSON(PS ps, const char outfile[]) {
   PrintJSONArray(fd, "LOADSHED", 2, &ps->sys_info.total_loadshed[0], true);
 
   PrintJSONDouble(fd, "SolveRealTime", ps->solve_real_time, true);
-  PrintJSONDouble(fd, "SolveCPUTime", ps->solve_cpu_time, false);
 
   PrintJSONObjectEnd(fd, false); // System summary object end
 
@@ -887,7 +885,6 @@ PetscErrorCode PSSaveSolution_MINIMAL(PS ps, const char outfile[]) {
   fprintf(fd, "\tTotal Load Shed P, Q: %9g, %9g\n",
           ps->sys_info.total_loadshed[0], ps->sys_info.total_loadshed[1]);
   fprintf(fd, "\tSolve Time: %5g\n", ps->solve_real_time);
-  fprintf(fd, "\tSolve CPU Time: %5g\n", ps->solve_cpu_time);
 
   fclose(fd);
 


### PR DESCRIPTION
**Merge request type**
- [x] Other

**Relates to**
- [x] OPFLOW

**This MR updates**
- [x] Header files
- [x] Source code

**Summary**

Fixes #108.  "CPU" solve time is no longer in output. 
