### PR TITLE
Do not ouptut individual load parameters if not in original network

### DIFF
--- a/include/private/psimpl.h
+++ b/include/private/psimpl.h
@@ -451,6 +451,8 @@ struct _p_PS {
 
   PSSystemSummary sys_info;
 
+  PetscBool read_load_cost;     /* are individual load costs assigned? */
+
   PetscBool setupcalled; /* Is setup called on PS? */
 
   PetscLogDouble solve_real_time;

--- a/include/private/psimpl.h
+++ b/include/private/psimpl.h
@@ -451,7 +451,7 @@ struct _p_PS {
 
   PSSystemSummary sys_info;
 
-  PetscBool read_load_cost;     /* are individual load costs assigned? */
+  PetscBool read_load_cost; /* are individual load costs assigned? */
 
   PetscBool setupcalled; /* Is setup called on PS? */
 

--- a/src/ps/psoutput.cpp
+++ b/src/ps/psoutput.cpp
@@ -232,22 +232,25 @@ PetscErrorCode PSSaveSolution_MATPOWER(PS ps, const char outfile[]) {
     fprintf(fd, "\n};\n");
   }
 
-  /* Load cost data */
-  fprintf(fd, "\n%%%% load cost data\n");
-  fprintf(fd, "%% %%maxallowedloadshed loadshedcost\n");
-  fprintf(fd, "mpc.loadcost = [\n");
-  for (i = 0; i < ps->nbus; i++) {
-    bus = &ps->bus[i];
-    for (k = 0; k < bus->nload; k++) {
-      PSLOAD load;
-      ierr = PSBUSGetLoad(bus, k, &load);
-      CHKERRQ(ierr);
-      fprintf(fd, "%10.5g %10.5g; \n", load->loss_frac * 100.0,
-              load->loss_cost);
-    }
-  }
-  fprintf(fd, "];\n");
+  if (ps->read_load_cost) {
 
+    /* Load cost data */
+    fprintf(fd, "\n%%%% load cost data\n");
+    fprintf(fd, "%% %%maxallowedloadshed loadshedcost\n");
+    fprintf(fd, "mpc.loadcost = [\n");
+    for (i = 0; i < ps->nbus; i++) {
+      bus = &ps->bus[i];
+      for (k = 0; k < bus->nload; k++) {
+        PSLOAD load;
+        ierr = PSBUSGetLoad(bus, k, &load);
+        CHKERRQ(ierr);
+        fprintf(fd, "%10.5g %10.5g; \n", load->loss_frac * 100.0,
+                load->loss_cost);
+      }
+    }
+    fprintf(fd, "];\n");
+  }
+    
   /* Solution summary info */
   fprintf(fd, "\n%%%% summary data\n");
   fprintf(fd, "%ssummary_stats = [\n", prefix);

--- a/src/ps/psoutput.cpp
+++ b/src/ps/psoutput.cpp
@@ -250,7 +250,7 @@ PetscErrorCode PSSaveSolution_MATPOWER(PS ps, const char outfile[]) {
     }
     fprintf(fd, "];\n");
   }
-    
+
   /* Solution summary info */
   fprintf(fd, "\n%%%% summary data\n");
   fprintf(fd, "%ssummary_stats = [\n", prefix);

--- a/src/ps/psreaddata.cpp
+++ b/src/ps/psreaddata.cpp
@@ -824,7 +824,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
              &Load[loadcosti].loss_cost);
       Load[loadcosti].loss_frac /= 100; /* Convert to fraction */
       loadcosti++;
-    } 
+    }
 
     /* Read generator fuel data */
     if (i >= genfuel_start_line && i < genfuel_end_line) {

--- a/src/ps/psreaddata.cpp
+++ b/src/ps/psreaddata.cpp
@@ -539,6 +539,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
 
   ps->Nload = 0;
   ps->maxbusnum = -1;
+  ps->read_load_cost = PETSC_FALSE;
   while ((out = fgets(line, MAXLINE, fp)) != NULL) {
     if (strstr(line, "mpc.baseMVA")) {
       /* Read base MVA */
@@ -557,6 +558,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
       gencost_start_line =
           line_counter + 1; /* Gen cost data starts from next line */
     if (strstr(line, "mpc.loadcost") != NULL) {
+      ps->read_load_cost = PETSC_TRUE;
       loadcost_start_line =
           line_counter + 1; /* Load cost data starts from next line */
     }
@@ -822,7 +824,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
              &Load[loadcosti].loss_cost);
       Load[loadcosti].loss_frac /= 100; /* Convert to fraction */
       loadcosti++;
-    }
+    } 
 
     /* Read generator fuel data */
     if (i >= genfuel_start_line && i < genfuel_end_line) {


### PR DESCRIPTION
**Merge request type**
- [x] Resolves bug

**Relates to**
- [x] OPFLOW

**This MR updates**
- [x] Header files
- [x] Source code

**Summary**

Load shedding parameters can be individually by each load using the `mpc.loadcost` field in the MATPOWER network.  These individual load loss parameters were added to the output even if they were never specified or used.  This fixes that. Individual load shedding parameters are output only if they were read from the input network. Closes #109.  

If load shedding parameters are not read from the input network, they are initialized with the OPFLOW blanket cost (`-opflow_loadloss_penality`), but only if needed (`-opflow_include_loadloss_variables`).  

