### PR TITLE
Mark solar and hydro as renewables. Set solar lower bound to zero.

### DIFF
--- a/src/ps/psreaddata.cpp
+++ b/src/ps/psreaddata.cpp
@@ -855,6 +855,8 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
         Gen[genfueli].ramp_rate_min = GENRAMPRATE_SOLAR / ps->MVAbase;
         Gen[genfueli].ramp_rate_10min = Gen[genfueli].ramp_rate_min * 10;
         Gen[genfueli].ramp_rate_30min = Gen[genfueli].ramp_rate_min * 30;
+	Gen[genfueli].pb = 0.0; /* Set lower Pg limit to 0.0 so that power
+                                   can be curtailed if need be */
         ps->ngensolar++;
         ps->ngenrenew++;
         Gen[genfueli].isrenewable = PETSC_TRUE;
@@ -870,6 +872,8 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
         Gen[genfueli].ramp_rate_10min = Gen[genfueli].ramp_rate_min * 10;
         Gen[genfueli].ramp_rate_30min = Gen[genfueli].ramp_rate_min * 30;
         ps->ngenhydro++;
+	ps->ngenrenew++;
+        Gen[genfueli].isrenewable = PETSC_TRUE;
       } else {
         Gen[genfueli].genfuel_type = GENFUEL_UNDEFINED;
         Gen[genfueli].ramp_rate_min =

--- a/src/ps/psreaddata.cpp
+++ b/src/ps/psreaddata.cpp
@@ -855,7 +855,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
         Gen[genfueli].ramp_rate_min = GENRAMPRATE_SOLAR / ps->MVAbase;
         Gen[genfueli].ramp_rate_10min = Gen[genfueli].ramp_rate_min * 10;
         Gen[genfueli].ramp_rate_30min = Gen[genfueli].ramp_rate_min * 30;
-	Gen[genfueli].pb = 0.0; /* Set lower Pg limit to 0.0 so that power
+        Gen[genfueli].pb = 0.0; /* Set lower Pg limit to 0.0 so that power
                                    can be curtailed if need be */
         ps->ngensolar++;
         ps->ngenrenew++;
@@ -872,7 +872,7 @@ PetscErrorCode PSReadMatPowerData(PS ps, const char netfile[]) {
         Gen[genfueli].ramp_rate_10min = Gen[genfueli].ramp_rate_min * 10;
         Gen[genfueli].ramp_rate_30min = Gen[genfueli].ramp_rate_min * 30;
         ps->ngenhydro++;
-	ps->ngenrenew++;
+        ps->ngenrenew++;
         Gen[genfueli].isrenewable = PETSC_TRUE;
       } else {
         Gen[genfueli].genfuel_type = GENFUEL_UNDEFINED;


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [x ] Other

**This MR updates**
- [ ] Header files
- [ x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**
Mark solar and hydro generators as renewables when reading the data. Set the lower generation limit of solar to zero.