### PR TITLE
Update petsc version installing_with_spack.md

### DIFF
--- a/docs/installing_with_spack.md
+++ b/docs/installing_with_spack.md
@@ -36,7 +36,7 @@ source /path-to-spack/share/spack/setup-env.sh
 spack compiler find
 spack install exago@develop%gcc \
   ^openmpi ^ipopt@3.12.10+coinhsl~mumps ^coinhsl+blas \
-  ^petsc@3.19+mpi~hypre~superlu-dist~mumps+shared
+  ^petsc+mpi~hypre~superlu-dist~mumps+shared
 spack load exago
 opflow -help
 ```

--- a/docs/installing_with_spack.md
+++ b/docs/installing_with_spack.md
@@ -36,7 +36,7 @@ source /path-to-spack/share/spack/setup-env.sh
 spack compiler find
 spack install exago@develop%gcc \
   ^openmpi ^ipopt@3.12.10+coinhsl~mumps ^coinhsl+blas \
-  ^petsc@3.13.6+mpi~hypre~superlu-dist~mumps+shared
+  ^petsc@3.19+mpi~hypre~superlu-dist~mumps+shared
 spack load exago
 opflow -help
 ```


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [x] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [x] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [x] Manual
- [ ] Other

**Summary**

It appears the Spack installation instructions are outdated. I received the following error:

```
ubuntu@workstation:~$ spack install exago@develop%gcc \
  ^openmpi ^ipopt@3.12.10+coinhsl~mumps ^coinhsl+blas \
  ^petsc@3.13.6+mpi~hypre~superlu-dist~mumps+shared
==> Error: concretization failed for the following reasons:

   1. Cannot select a single "version" for package "petsc"
   2. Cannot satisfy 'petsc@:3.13'
   3. Cannot satisfy 'petsc@3.20'
   4. Cannot satisfy 'petsc@3.19:'
   5. Cannot satisfy 'petsc@3.18:'
   6. Cannot satisfy 'petsc@3.13:3.14'
   7. Cannot satisfy 'petsc@3.13.6'
   8. Cannot satisfy 'petsc@3.11:3.13'
   9. Cannot satisfy 'petsc@3.19:'
        required because exago depends on petsc@3.19: when @1.6: 
          required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly 
   10. Cannot satisfy 'petsc@3.13.6'
        required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly 
   11. Cannot satisfy 'petsc@3.19:' and 'petsc@3.13.6
        required because exago depends on petsc@3.19: when @1.6: 
          required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly 
        required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly 
   12. Cannot satisfy 'petsc@3.13.6' and 'petsc@3.19:
        required because exago depends on petsc@3.19: when @1.6: 
          required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly 
        required because exago@develop%gcc ^coinhsl+blas ^ipopt@3.12.10+coinhsl~mumps ^openmpi ^petsc@3.13.6~hypre+mpi~mumps+shared~superlu-dist requested explicitly
```

Specifying petsc version 3.19 as the required version allowed me to continue installation.
