### PR TITLE
Buildsystem update for Frontier using the worldshared directory and rocm/5.6

### DIFF
--- a/buildsystem/clang-hip/cache.cmake
+++ b/buildsystem/clang-hip/cache.cmake
@@ -1,4 +1,4 @@
-message(STATUS "Loading CMake cache for a GCC+CUDA+MPI build")
+message(STATUS "Loading CMake cache for a GCC+HIP+MPI build")
 
 set(prefix ${CMAKE_SOURCE_DIR}/install)
 message(STATUS "Setting initial installation prefix to ${prefix}")

--- a/buildsystem/clang-hip/crusher/base.sh
+++ b/buildsystem/clang-hip/crusher/base.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export MY_CLUSTER=crusher
-export PROJ_DIR=/autofs/nccs-svm1_proj/csc359
+export PROJ_DIR=/autofs/nccs-svm1_proj/eng145
 
 module reset
 

--- a/buildsystem/clang-hip/crusher/base.sh
+++ b/buildsystem/clang-hip/crusher/base.sh
@@ -9,15 +9,15 @@ module reset
 module load PrgEnv-gnu-amd
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
-module load amd-mixed/5.2.0
+module load amd-mixed/5.6.0
 module load gcc/12.2.0
 module load cray-mpich/8.1.25
 module load libfabric
 
 # Consider changing to $(which clang) as for deception
-export CC=/opt/rocm-5.2.0/llvm/bin/amdclang
-export CXX=/opt/rocm-5.2.0/llvm/bin/amdclang++
-export FC=/opt/rocm-5.2.0/llvm/bin/amdflang
+export CC=/opt/rocm-5.6.0/llvm/bin/amdclang
+export CXX=/opt/rocm-5.6.0/llvm/bin/amdclang++
+export FC=/opt/rocm-5.6.0/llvm/bin/amdflang
 
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DEXAGO_CTEST_LAUNCH_COMMAND='srun'"
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DAMDGPU_TARGETS='gfx90a'"

--- a/buildsystem/spack/crusher/env.sh
+++ b/buildsystem/spack/crusher/env.sh
@@ -3,9 +3,9 @@
 # Configure python
 module load cray-python/3.9.12.1 
 
-BASE=/lustre/orion/eng145/proj-shared/$(whoami)
+BASE=/lustre/orion/eng145/world-shared/$(whoami)
 
-export SPACK_INSTALL=/lustre/orion/eng145/proj-shared/nkouk/spack-install
+export SPACK_INSTALL=/lustre/orion/eng145/world-shared/spack-install
 export SPACK_MODULES=modules
 export SPACK_CACHE=$BASE/spack-cache
 export SPACK_MIRROR=$BASE/spack-mirror

--- a/buildsystem/spack/crusher/env.sh
+++ b/buildsystem/spack/crusher/env.sh
@@ -3,9 +3,9 @@
 # Configure python
 module load cray-python/3.9.12.1 
 
-BASE=/lustre/orion/csc359/proj-shared/$(whoami)
+BASE=/lustre/orion/eng145/proj-shared/$(whoami)
 
-export SPACK_INSTALL=/lustre/orion/csc359/proj-shared/nkouk/spack-install
+export SPACK_INSTALL=/lustre/orion/eng145/proj-shared/nkouk/spack-install
 export SPACK_MODULES=modules
 export SPACK_CACHE=$BASE/spack-cache
 export SPACK_MIRROR=$BASE/spack-mirror

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,111 +1,101 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
-# gmake@=4.4.1%clang@=14.0.0-rocm5.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
-module load gmake/4.4.1-clang-14.0.0-rocm5.2.0-mixed-7vcngsz
-# pkgconf@=1.9.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load pkgconf/1.9.5-clang-14.0.0-rocm5.2.0-mixed-4swj7eh
-# nghttp2@=1.57.0%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load nghttp2/1.57.0-clang-14.0.0-rocm5.2.0-mixed-iwxpikh
-# ca-certificates-mozilla@=2023-05-30%clang@=14.0.0-rocm5.2.0-mixed build_system=generic arch=linux-sles15-zen3
-module load ca-certificates-mozilla/2023-05-30-clang-14.0.0-rocm5.2.0-mixed-q3hsdil
-# perl@=5.34.0%clang@=14.0.0-rocm5.2.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-zen3
-module load perl/5.34.0-clang-14.0.0-rocm5.2.0-mixed-ex2kxdz
-# zlib-ng@=2.1.5%clang@=14.0.0-rocm5.2.0-mixed+compat+opt build_system=autotools arch=linux-sles15-zen3
-module load zlib-ng/2.1.5-clang-14.0.0-rocm5.2.0-mixed-nhxuhp3
-# openssl@=3.1.3%clang@=14.0.0-rocm5.2.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-zen3
-## module load openssl/3.1.3-clang-14.0.0-rocm5.2.0-mixed-y5566cf
-# curl@=8.4.0%clang@=14.0.0-rocm5.2.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-zen3
-module load curl/8.4.0-clang-14.0.0-rocm5.2.0-mixed-2yz3o3v
-# ncurses@=6.4%clang@=14.0.0-rocm5.2.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-zen3
-module load ncurses/6.4-clang-14.0.0-rocm5.2.0-mixed-vy6yuss
-# cmake@=3.20.6%clang@=14.0.0-rocm5.2.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-zen3
-module load cmake/3.20.6-clang-14.0.0-rocm5.2.0-mixed-lilujjv
-# blt@=0.4.1%clang@=14.0.0-rocm5.2.0-mixed build_system=generic arch=linux-sles15-zen3
-module load blt/0.4.1-clang-14.0.0-rocm5.2.0-mixed-pihruyq
-# hip@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=959d1fe,c2ee21c arch=linux-sles15-zen3
-module load hip/5.2.0-clang-14.0.0-rocm5.2.0-mixed-6ftqihk
-# hsa-rocr-dev@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~asan+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-zen3
-module load hsa-rocr-dev/5.2.0-clang-14.0.0-rocm5.2.0-mixed-p6fvpym
-# llvm-amdgpu@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1 arch=linux-sles15-zen3
-module load llvm-amdgpu/5.2.0-clang-14.0.0-rocm5.2.0-mixed-7g3i4ov
-# camp@=0.2.3%clang@=14.0.0-rocm5.2.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load camp/0.2.3-clang-14.0.0-rocm5.2.0-mixed-5hqx2ao
-# cray-mpich@=8.1.25%clang@=14.0.0-rocm5.2.0-mixed+wrappers build_system=generic arch=linux-sles15-zen3
-module load cray-mpich/8.1.25-clang-14.0.0-rocm5.2.0-mixed-qd6s47h
-# hipblas@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipblas/5.2.0-clang-14.0.0-rocm5.2.0-mixed-pz2pdk4
-# hipfft@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hipfft/5.2.0-clang-14.0.0-rocm5.2.0-mixed-pje75d4
-# hiprand@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hiprand/5.2.0-clang-14.0.0-rocm5.2.0-mixed-224knmx
-# hipsparse@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=c447537 arch=linux-sles15-zen3
-module load hipsparse/5.2.0-clang-14.0.0-rocm5.2.0-mixed-vqshjsa
-# rocprim@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocprim/5.2.0-clang-14.0.0-rocm5.2.0-mixed-6jqmhkg
-# rocrand@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed+hiprand amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=a35e689 arch=linux-sles15-zen3
-module load rocrand/5.2.0-clang-14.0.0-rocm5.2.0-mixed-nwexus7
-# rocthrust@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load rocthrust/5.2.0-clang-14.0.0-rocm5.2.0-mixed-3upg7wr
-# ginkgo@=1.5.0.glu_experimental%clang@=14.0.0-rocm5.2.0-mixed~cuda~develtools~full_optimizations~hwloc~ipo~mpi~openmp+rocm+shared~sycl amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=ba0956e arch=linux-sles15-zen3
-module load ginkgo/1.5.0.glu_experimental-clang-14.0.0-rocm5.2.0-mixed-6bembpq
-# gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
-module load gmake/4.4.1-gcc-12.2.0-mixed-svg2oxk
-# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-zen3
-module load openblas/0.3.20-gcc-12.2.0-mixed-lkwa4l7
-# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-zen3
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-4lf6df7
-# magma@=2.6.2%clang@=14.0.0-rocm5.2.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load magma/2.6.2-clang-14.0.0-rocm5.2.0-mixed-5v4sbqv
-# metis@=5.1.0%clang@=14.0.0-rocm5.2.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
-module load metis/5.1.0-clang-14.0.0-rocm5.2.0-mixed-3loietj
-# raja@=0.14.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load raja/0.14.0-clang-14.0.0-rocm5.2.0-mixed-plistg5
-# libiconv@=1.17%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load libiconv/1.17-clang-14.0.0-rocm5.2.0-mixed-gryio4w
-# diffutils@=3.9%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load diffutils/3.9-clang-14.0.0-rocm5.2.0-mixed-yz7kuqz
-# libsigsegv@=2.14%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load libsigsegv/2.14-clang-14.0.0-rocm5.2.0-mixed-mjraljk
-# m4@=1.4.19%clang@=14.0.0-rocm5.2.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-zen3
-module load m4/1.4.19-clang-14.0.0-rocm5.2.0-mixed-xrlual5
-# autoconf@=2.69%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-sles15-zen3
-module load autoconf/2.69-clang-14.0.0-rocm5.2.0-mixed-4q2ohdh
-# automake@=1.16.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load automake/1.16.5-clang-14.0.0-rocm5.2.0-mixed-vpi6wmc
-# libtool@=2.4.7%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load libtool/2.4.7-clang-14.0.0-rocm5.2.0-mixed-lm5hq6p
-# gmp@=6.2.1%clang@=14.0.0-rocm5.2.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-zen3
-module load gmp/6.2.1-clang-14.0.0-rocm5.2.0-mixed-kvk75vv
-# autoconf-archive@=2023.02.20%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load autoconf-archive/2023.02.20-clang-14.0.0-rocm5.2.0-mixed-2gml5wh
-# bzip2@=1.0.8%clang@=14.0.0-rocm5.2.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-zen3
-module load bzip2/1.0.8-clang-14.0.0-rocm5.2.0-mixed-e22jeoj
-# xz@=5.4.1%clang@=14.0.0-rocm5.2.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load xz/5.4.1-clang-14.0.0-rocm5.2.0-mixed-il6uern
-# libxml2@=2.10.3%clang@=14.0.0-rocm5.2.0-mixed+pic~python+shared build_system=autotools arch=linux-sles15-zen3
-module load libxml2/2.10.3-clang-14.0.0-rocm5.2.0-mixed-rs5hdf4
-# pigz@=2.7%clang@=14.0.0-rocm5.2.0-mixed build_system=makefile arch=linux-sles15-zen3
-module load pigz/2.7-clang-14.0.0-rocm5.2.0-mixed-ghuoaqc
-# zstd@=1.5.5%clang@=14.0.0-rocm5.2.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-zen3
-module load zstd/1.5.5-clang-14.0.0-rocm5.2.0-mixed-q7yzxzw
-# tar@=1.34%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools zip=pigz arch=linux-sles15-zen3
-module load tar/1.34-clang-14.0.0-rocm5.2.0-mixed-xjye57q
-# gettext@=0.22.4%clang@=14.0.0-rocm5.2.0-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-zen3
-module load gettext/0.22.4-clang-14.0.0-rocm5.2.0-mixed-mdy7wdc
-# texinfo@=7.0.3%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
-module load texinfo/7.0.3-clang-14.0.0-rocm5.2.0-mixed-zpog5zs
-# mpfr@=4.2.0%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
-module load mpfr/4.2.0-clang-14.0.0-rocm5.2.0-mixed-k6y6ufe
-# suite-sparse@=5.13.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-zen3
-module load suite-sparse/5.13.0-clang-14.0.0-rocm5.2.0-mixed-vfmchqd
-# umpire@=6.0.0%clang@=14.0.0-rocm5.2.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-zen3
-module load umpire/6.0.0-clang-14.0.0-rocm5.2.0-mixed-q3vler4
-# hiop@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load hiop/develop-clang-14.0.0-rocm5.2.0-mixed-jxs7pn7
-# ipopt@=3.12.10%clang@=14.0.0-rocm5.2.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-zen3
-module load ipopt/3.12.10-clang-14.0.0-rocm5.2.0-mixed-di6sy6h
-# python@=3.9.12%clang@=14.0.0-rocm5.2.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-zen3
-module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-rmdxnw5
-# petsc@=3.20.2%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.20.2-clang-14.0.0-rocm5.2.0-mixed-lnhejpn
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/eng145/ExaGO generator=make arch=linux-sles15-zen3
-## module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-stynmti
+# gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
+module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-k6al2qo
+# pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-uouwfb7
+# nghttp2@=1.57.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load nghttp2/1.57.0-clang-16.0.0-rocm5.6.0-mixed-4mp6nud
+# ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
+module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-b35brx3
+# perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-kz4eken
+# zlib-ng@=2.1.4%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools arch=linux-sles15-x86_64
+module load zlib-ng/2.1.4-clang-16.0.0-rocm5.6.0-mixed-3qkqsle
+# openssl@=3.1.3%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
+## module load openssl/3.1.3-clang-16.0.0-rocm5.6.0-mixed-z2b2n2v
+# curl@=8.4.0%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
+module load curl/8.4.0-clang-16.0.0-rocm5.6.0-mixed-f6bnt2g
+# ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
+module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-epb33eo
+# cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
+module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-yaow2oz
+# blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
+module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-7cfyib3
+# hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-x86_64
+module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-op3qkhw
+# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-x86_64
+module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ezukiit
+# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,b66529f,d35aec9 arch=linux-sles15-x86_64
+module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-hywg6dz
+# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-bpoapxo
+# cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-x86_64
+module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-7mbfpyl
+# gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
+module load gmake/4.4.1-gcc-12.2.0-mixed-j4cmkzq
+# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
+module load openblas/0.3.20-gcc-12.2.0-mixed-tq6djj3
+# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-x86_64
+module load coinhsl/2019.05.21-gcc-12.2.0-mixed-tafgcu3
+# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-lckx2a7
+# hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-v2eembx
+# magma@=2.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load magma/2.7.2-clang-16.0.0-rocm5.6.0-mixed-yfghydp
+# metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
+module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-odzstni
+# rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-mbf63yj
+# raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-z6v3hxh
+# libiconv@=1.17%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load libiconv/1.17-clang-16.0.0-rocm5.6.0-mixed-2aglobu
+# diffutils@=3.9%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load diffutils/3.9-clang-16.0.0-rocm5.6.0-mixed-b7kmhwy
+# libsigsegv@=2.14%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libsigsegv/2.14-clang-16.0.0-rocm5.6.0-mixed-bdwxxrb
+# m4@=1.4.19%clang@=16.0.0-rocm5.6.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
+module load m4/1.4.19-clang-16.0.0-rocm5.6.0-mixed-yehligm
+# autoconf@=2.69%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-sles15-x86_64
+module load autoconf/2.69-clang-16.0.0-rocm5.6.0-mixed-dnxxoh2
+# automake@=1.16.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load automake/1.16.5-clang-16.0.0-rocm5.6.0-mixed-3mm4fm5
+# libtool@=2.4.7%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libtool/2.4.7-clang-16.0.0-rocm5.6.0-mixed-23ehtda
+# gmp@=6.2.1%clang@=16.0.0-rocm5.6.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
+module load gmp/6.2.1-clang-16.0.0-rocm5.6.0-mixed-t5hlxtw
+# autoconf-archive@=2023.02.20%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load autoconf-archive/2023.02.20-clang-16.0.0-rocm5.6.0-mixed-exate7t
+# bzip2@=1.0.8%clang@=16.0.0-rocm5.6.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
+module load bzip2/1.0.8-clang-16.0.0-rocm5.6.0-mixed-jcvtab5
+# xz@=5.4.1%clang@=16.0.0-rocm5.6.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load xz/5.4.1-clang-16.0.0-rocm5.6.0-mixed-jny6a2y
+# libxml2@=2.10.3%clang@=16.0.0-rocm5.6.0-mixed+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
+module load libxml2/2.10.3-clang-16.0.0-rocm5.6.0-mixed-bwzce2v
+# pigz@=2.7%clang@=16.0.0-rocm5.6.0-mixed build_system=makefile arch=linux-sles15-x86_64
+module load pigz/2.7-clang-16.0.0-rocm5.6.0-mixed-hndhspi
+# zstd@=1.5.5%clang@=16.0.0-rocm5.6.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
+module load zstd/1.5.5-clang-16.0.0-rocm5.6.0-mixed-w7bcfca
+# tar@=1.34%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools zip=pigz arch=linux-sles15-x86_64
+module load tar/1.34-clang-16.0.0-rocm5.6.0-mixed-yvw47t5
+# gettext@=0.22.3%clang@=16.0.0-rocm5.6.0-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
+module load gettext/0.22.3-clang-16.0.0-rocm5.6.0-mixed-iliwbcy
+# texinfo@=7.0.3%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load texinfo/7.0.3-clang-16.0.0-rocm5.6.0-mixed-gkcyjes
+# mpfr@=4.2.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load mpfr/4.2.0-clang-16.0.0-rocm5.6.0-mixed-j5g7ch2
+# suite-sparse@=5.13.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
+module load suite-sparse/5.13.0-clang-16.0.0-rocm5.6.0-mixed-riysyew
+# umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
+module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-2li2g3r
+# hiop@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hiop/develop-clang-16.0.0-rocm5.6.0-mixed-3ozi52g
+# ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
+module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-rlgcopl
+# python@=3.9.12%clang@=16.0.0-rocm5.6.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-x86_64
+module load python/3.9.12-clang-16.0.0-rocm5.6.0-mixed-mdt6uvm
+# petsc@=3.20.1%clang@=16.0.0-rocm5.6.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
+module load petsc/3.20.1-clang-16.0.0-rocm5.6.0-mixed-pa2upkm
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-6xcrrvo

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,4 +1,4 @@
-module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
 # gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
 module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-k6al2qo
 # pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,4 +1,4 @@
-module use -a /lustre/orion/eng145/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
 # gmake@=4.4.1%clang@=14.0.0-rocm5.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
 module load gmake/4.4.1-clang-14.0.0-rocm5.2.0-mixed-7vcngsz
 # pkgconf@=1.9.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,101 +1,107 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
 # gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
-module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-k6al2qo
+module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-4d3igqq
 # pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-uouwfb7
+module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-3xhjflz
 # nghttp2@=1.57.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load nghttp2/1.57.0-clang-16.0.0-rocm5.6.0-mixed-4mp6nud
+module load nghttp2/1.57.0-clang-16.0.0-rocm5.6.0-mixed-sdtjvwe
 # ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
 module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-b35brx3
 # perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
-module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-kz4eken
-# zlib-ng@=2.1.4%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools arch=linux-sles15-x86_64
-module load zlib-ng/2.1.4-clang-16.0.0-rocm5.6.0-mixed-3qkqsle
-# openssl@=3.1.3%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
-## module load openssl/3.1.3-clang-16.0.0-rocm5.6.0-mixed-z2b2n2v
-# curl@=8.4.0%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
-module load curl/8.4.0-clang-16.0.0-rocm5.6.0-mixed-f6bnt2g
+module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-o4kwhsx
+# zlib-ng@=2.1.6%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools arch=linux-sles15-x86_64
+module load zlib-ng/2.1.6-clang-16.0.0-rocm5.6.0-mixed-k6jftme
+# openssl@=3.2.1%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
+## module load openssl/3.2.1-clang-16.0.0-rocm5.6.0-mixed-3mhtqmf
+# curl@=8.6.0%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
+module load curl/8.6.0-clang-16.0.0-rocm5.6.0-mixed-ov7e2ec
 # ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
-module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-epb33eo
+module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-xmy4ha6
 # cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
-module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-yaow2oz
+module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-cdzi5pg
 # blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
-module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-7cfyib3
+module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-brf75se
 # hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-x86_64
-module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-op3qkhw
-# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-x86_64
-module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ezukiit
-# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,b66529f,d35aec9 arch=linux-sles15-x86_64
-module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-hywg6dz
-# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-bpoapxo
+module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-2mz3gxg
+# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~asan+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-x86_64
+module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-l76bkwj
+# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,b66529f,d35aec9 arch=linux-sles15-x86_64
+module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-dewtyvf
+# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=cb9e25b arch=linux-sles15-x86_64
+module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-xikgz56
 # cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-x86_64
-module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-7mbfpyl
+module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-qr5dmb6
+# gcc-runtime@=12.2.0-mixed%gcc@=12.2.0-mixed build_system=generic arch=linux-sles15-x86_64
+module load gcc-runtime/12.2.0-mixed-gcc-12.2.0-mixed-bzp6esl
 # gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
-module load gmake/4.4.1-gcc-12.2.0-mixed-j4cmkzq
+module load gmake/4.4.1-gcc-12.2.0-mixed-w6sfqlw
+# perl@=5.34.0%gcc@=12.2.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+module load perl/5.34.0-gcc-12.2.0-mixed-45ygmu5
 # openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
-module load openblas/0.3.20-gcc-12.2.0-mixed-tq6djj3
+module load openblas/0.3.20-gcc-12.2.0-mixed-cjm2rkd
 # coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-x86_64
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-tafgcu3
-# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-lckx2a7
+module load coinhsl/2019.05.21-gcc-12.2.0-mixed-and6kty
+# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=f1b0687 arch=linux-sles15-x86_64
+module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-pgkobjo
 # hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-v2eembx
+module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ekd6wr5
 # magma@=2.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load magma/2.7.2-clang-16.0.0-rocm5.6.0-mixed-yfghydp
+module load magma/2.7.2-clang-16.0.0-rocm5.6.0-mixed-b2w675g
 # metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
-module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-odzstni
+module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-2az7z3w
 # rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-mbf63yj
+module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-hh2g4wl
 # raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-z6v3hxh
+module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-xbpm7ni
 # libiconv@=1.17%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load libiconv/1.17-clang-16.0.0-rocm5.6.0-mixed-2aglobu
+module load libiconv/1.17-clang-16.0.0-rocm5.6.0-mixed-naqxaw5
 # diffutils@=3.9%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load diffutils/3.9-clang-16.0.0-rocm5.6.0-mixed-b7kmhwy
+module load diffutils/3.9-clang-16.0.0-rocm5.6.0-mixed-dh5ipjd
 # libsigsegv@=2.14%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load libsigsegv/2.14-clang-16.0.0-rocm5.6.0-mixed-bdwxxrb
+module load libsigsegv/2.14-clang-16.0.0-rocm5.6.0-mixed-f2emrox
 # m4@=1.4.19%clang@=16.0.0-rocm5.6.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
-module load m4/1.4.19-clang-16.0.0-rocm5.6.0-mixed-yehligm
-# autoconf@=2.69%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-sles15-x86_64
-module load autoconf/2.69-clang-16.0.0-rocm5.6.0-mixed-dnxxoh2
+module load m4/1.4.19-clang-16.0.0-rocm5.6.0-mixed-xemq6xh
+# autoconf@=2.72%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
+module load autoconf/2.72-clang-16.0.0-rocm5.6.0-mixed-7fvtern
 # automake@=1.16.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load automake/1.16.5-clang-16.0.0-rocm5.6.0-mixed-3mm4fm5
+module load automake/1.16.5-clang-16.0.0-rocm5.6.0-mixed-3p2ykck
+# findutils@=4.9.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools patches=440b954 arch=linux-sles15-x86_64
+module load findutils/4.9.0-clang-16.0.0-rocm5.6.0-mixed-b2j6llu
 # libtool@=2.4.7%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load libtool/2.4.7-clang-16.0.0-rocm5.6.0-mixed-23ehtda
+module load libtool/2.4.7-clang-16.0.0-rocm5.6.0-mixed-s7mxgfu
 # gmp@=6.2.1%clang@=16.0.0-rocm5.6.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
-module load gmp/6.2.1-clang-16.0.0-rocm5.6.0-mixed-t5hlxtw
+module load gmp/6.2.1-clang-16.0.0-rocm5.6.0-mixed-3gygkj2
 # autoconf-archive@=2023.02.20%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load autoconf-archive/2023.02.20-clang-16.0.0-rocm5.6.0-mixed-exate7t
+module load autoconf-archive/2023.02.20-clang-16.0.0-rocm5.6.0-mixed-2j34bwo
 # bzip2@=1.0.8%clang@=16.0.0-rocm5.6.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
-module load bzip2/1.0.8-clang-16.0.0-rocm5.6.0-mixed-jcvtab5
-# xz@=5.4.1%clang@=16.0.0-rocm5.6.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load xz/5.4.1-clang-16.0.0-rocm5.6.0-mixed-jny6a2y
+module load bzip2/1.0.8-clang-16.0.0-rocm5.6.0-mixed-zmolwma
+# xz@=5.4.6%clang@=16.0.0-rocm5.6.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load xz/5.4.6-clang-16.0.0-rocm5.6.0-mixed-heumicj
 # libxml2@=2.10.3%clang@=16.0.0-rocm5.6.0-mixed+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
-module load libxml2/2.10.3-clang-16.0.0-rocm5.6.0-mixed-bwzce2v
-# pigz@=2.7%clang@=16.0.0-rocm5.6.0-mixed build_system=makefile arch=linux-sles15-x86_64
-module load pigz/2.7-clang-16.0.0-rocm5.6.0-mixed-hndhspi
+module load libxml2/2.10.3-clang-16.0.0-rocm5.6.0-mixed-blh43sg
+# pigz@=2.8%clang@=16.0.0-rocm5.6.0-mixed build_system=makefile arch=linux-sles15-x86_64
+module load pigz/2.8-clang-16.0.0-rocm5.6.0-mixed-4yfazjp
 # zstd@=1.5.5%clang@=16.0.0-rocm5.6.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
-module load zstd/1.5.5-clang-16.0.0-rocm5.6.0-mixed-w7bcfca
+module load zstd/1.5.5-clang-16.0.0-rocm5.6.0-mixed-oheyequ
 # tar@=1.34%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools zip=pigz arch=linux-sles15-x86_64
-module load tar/1.34-clang-16.0.0-rocm5.6.0-mixed-yvw47t5
-# gettext@=0.22.3%clang@=16.0.0-rocm5.6.0-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
-module load gettext/0.22.3-clang-16.0.0-rocm5.6.0-mixed-iliwbcy
+module load tar/1.34-clang-16.0.0-rocm5.6.0-mixed-pzu4tqg
+# gettext@=0.22.4%clang@=16.0.0-rocm5.6.0-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
+module load gettext/0.22.4-clang-16.0.0-rocm5.6.0-mixed-sqcwu4y
 # texinfo@=7.0.3%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load texinfo/7.0.3-clang-16.0.0-rocm5.6.0-mixed-gkcyjes
-# mpfr@=4.2.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load mpfr/4.2.0-clang-16.0.0-rocm5.6.0-mixed-j5g7ch2
+module load texinfo/7.0.3-clang-16.0.0-rocm5.6.0-mixed-rodb6i5
+# mpfr@=4.2.1%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load mpfr/4.2.1-clang-16.0.0-rocm5.6.0-mixed-qyezacq
 # suite-sparse@=5.13.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
-module load suite-sparse/5.13.0-clang-16.0.0-rocm5.6.0-mixed-riysyew
+module load suite-sparse/5.13.0-clang-16.0.0-rocm5.6.0-mixed-ezd62mz
 # umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
-module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-2li2g3r
+module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-gbrp7vf
 # hiop@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hiop/develop-clang-16.0.0-rocm5.6.0-mixed-3ozi52g
+module load hiop/develop-clang-16.0.0-rocm5.6.0-mixed-t6ikxk6
 # ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
-module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-rlgcopl
+module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-7fp33q6
 # python@=3.9.12%clang@=16.0.0-rocm5.6.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-x86_64
-module load python/3.9.12-clang-16.0.0-rocm5.6.0-mixed-mdt6uvm
-# petsc@=3.20.1%clang@=16.0.0-rocm5.6.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
-module load petsc/3.20.1-clang-16.0.0-rocm5.6.0-mixed-pa2upkm
+module load python/3.9.12-clang-16.0.0-rocm5.6.0-mixed-bn2m2fd
+# petsc@=3.20.4%clang@=16.0.0-rocm5.6.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
+module load petsc/3.20.4-clang-16.0.0-rocm5.6.0-mixed-zgcdpbe
 # exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-6xcrrvo
+## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-kqa5be2

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,4 +1,4 @@
-module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/eng145/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
 # gmake@=4.4.1%clang@=14.0.0-rocm5.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
 module load gmake/4.4.1-clang-14.0.0-rocm5.2.0-mixed-7vcngsz
 # pkgconf@=1.9.5%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
@@ -22,21 +22,15 @@ module load cmake/3.20.6-clang-14.0.0-rocm5.2.0-mixed-lilujjv
 # blt@=0.4.1%clang@=14.0.0-rocm5.2.0-mixed build_system=generic arch=linux-sles15-zen3
 module load blt/0.4.1-clang-14.0.0-rocm5.2.0-mixed-pihruyq
 # hip@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=959d1fe,c2ee21c arch=linux-sles15-zen3
-module load hip/5.2.0-clang-14.0.0-rocm5.2.0-mixed-26fjs6f
-# hsa-rocr-dev@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-zen3
-module load hsa-rocr-dev/5.2.0-clang-14.0.0-rocm5.2.0-mixed-44hnkkg
+module load hip/5.2.0-clang-14.0.0-rocm5.2.0-mixed-6ftqihk
+# hsa-rocr-dev@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~asan+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-zen3
+module load hsa-rocr-dev/5.2.0-clang-14.0.0-rocm5.2.0-mixed-p6fvpym
 # llvm-amdgpu@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~link_llvm_dylib~llvm_dylib~openmp+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1 arch=linux-sles15-zen3
-module load llvm-amdgpu/5.2.0-clang-14.0.0-rocm5.2.0-mixed-5a4f3fn
+module load llvm-amdgpu/5.2.0-clang-14.0.0-rocm5.2.0-mixed-7g3i4ov
 # camp@=0.2.3%clang@=14.0.0-rocm5.2.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load camp/0.2.3-clang-14.0.0-rocm5.2.0-mixed-nbmcmee
+module load camp/0.2.3-clang-14.0.0-rocm5.2.0-mixed-5hqx2ao
 # cray-mpich@=8.1.25%clang@=14.0.0-rocm5.2.0-mixed+wrappers build_system=generic arch=linux-sles15-zen3
 module load cray-mpich/8.1.25-clang-14.0.0-rocm5.2.0-mixed-qd6s47h
-# gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
-module load gmake/4.4.1-gcc-12.2.0-mixed-svg2oxk
-# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-zen3
-module load openblas/0.3.20-gcc-12.2.0-mixed-lkwa4l7
-# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-zen3
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-4lf6df7
 # hipblas@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
 module load hipblas/5.2.0-clang-14.0.0-rocm5.2.0-mixed-pz2pdk4
 # hipfft@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
@@ -52,13 +46,19 @@ module load rocrand/5.2.0-clang-14.0.0-rocm5.2.0-mixed-nwexus7
 # rocthrust@=5.2.0%clang@=14.0.0-rocm5.2.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
 module load rocthrust/5.2.0-clang-14.0.0-rocm5.2.0-mixed-3upg7wr
 # ginkgo@=1.5.0.glu_experimental%clang@=14.0.0-rocm5.2.0-mixed~cuda~develtools~full_optimizations~hwloc~ipo~mpi~openmp+rocm+shared~sycl amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=ba0956e arch=linux-sles15-zen3
-module load ginkgo/1.5.0.glu_experimental-clang-14.0.0-rocm5.2.0-mixed-fo65t4m
+module load ginkgo/1.5.0.glu_experimental-clang-14.0.0-rocm5.2.0-mixed-6bembpq
+# gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-zen3
+module load gmake/4.4.1-gcc-12.2.0-mixed-svg2oxk
+# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-zen3
+module load openblas/0.3.20-gcc-12.2.0-mixed-lkwa4l7
+# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-zen3
+module load coinhsl/2019.05.21-gcc-12.2.0-mixed-4lf6df7
 # magma@=2.6.2%clang@=14.0.0-rocm5.2.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load magma/2.6.2-clang-14.0.0-rocm5.2.0-mixed-plzqmiv
+module load magma/2.6.2-clang-14.0.0-rocm5.2.0-mixed-5v4sbqv
 # metis@=5.1.0%clang@=14.0.0-rocm5.2.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-zen3
 module load metis/5.1.0-clang-14.0.0-rocm5.2.0-mixed-3loietj
 # raja@=0.14.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
-module load raja/0.14.0-clang-14.0.0-rocm5.2.0-mixed-vf434zb
+module load raja/0.14.0-clang-14.0.0-rocm5.2.0-mixed-plistg5
 # libiconv@=1.17%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-zen3
 module load libiconv/1.17-clang-14.0.0-rocm5.2.0-mixed-gryio4w
 # diffutils@=3.9%clang@=14.0.0-rocm5.2.0-mixed build_system=autotools arch=linux-sles15-zen3
@@ -98,14 +98,14 @@ module load mpfr/4.2.0-clang-14.0.0-rocm5.2.0-mixed-k6y6ufe
 # suite-sparse@=5.13.0%clang@=14.0.0-rocm5.2.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-zen3
 module load suite-sparse/5.13.0-clang-14.0.0-rocm5.2.0-mixed-vfmchqd
 # umpire@=6.0.0%clang@=14.0.0-rocm5.2.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-zen3
-module load umpire/6.0.0-clang-14.0.0-rocm5.2.0-mixed-wbz3qxn
-# hiop@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel generator=make arch=linux-sles15-zen3
-module load hiop/develop-clang-14.0.0-rocm5.2.0-mixed-4tyssbz
+module load umpire/6.0.0-clang-14.0.0-rocm5.2.0-mixed-q3vler4
+# hiop@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda~deepchecking+ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-zen3
+module load hiop/develop-clang-14.0.0-rocm5.2.0-mixed-jxs7pn7
 # ipopt@=3.12.10%clang@=14.0.0-rocm5.2.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-zen3
 module load ipopt/3.12.10-clang-14.0.0-rocm5.2.0-mixed-di6sy6h
 # python@=3.9.12%clang@=14.0.0-rocm5.2.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-zen3
-module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-ylrkreb
-# petsc@=3.20.2%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.20.2-clang-14.0.0-rocm5.2.0-mixed-kzwzivo
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel dev_path=/lustre/orion/scratch/nkouk/csc359/ExaGO generator=make arch=linux-sles15-zen3
-## module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-h3wqolf
+module load python/3.9.12-clang-14.0.0-rocm5.2.0-mixed-rmdxnw5
+# petsc@=3.20.2%clang@=14.0.0-rocm5.2.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
+module load petsc/3.20.2-clang-14.0.0-rocm5.2.0-mixed-lnhejpn
+# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/eng145/ExaGO generator=make arch=linux-sles15-zen3
+## module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-stynmti

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
-module use -a /lustre/orion/csc359/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=MinSizeRel dev_path=/lustre/orion/scratch/nkouk/csc359/ExaGO generator=make arch=linux-sles15-zen3
-module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-h3wqolf
+module use -a /lustre/orion/eng145/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/eng145/ExaGO generator=make arch=linux-sles15-zen3
+module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-stynmti

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
 # exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-6xcrrvo
+module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-kqa5be2

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
-module use -a /lustre/orion/eng145/proj-shared/nkouk/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
 # exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/eng145/ExaGO generator=make arch=linux-sles15-zen3
 module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-stynmti

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
-# exago@=develop%clang@=14.0.0-rocm5.2.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/eng145/ExaGO generator=make arch=linux-sles15-zen3
-module load exago/develop-clang-14.0.0-rocm5.2.0-mixed-stynmti
+# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-6xcrrvo

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
-module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-zen3
+module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
 # exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
 module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-6xcrrvo

--- a/buildsystem/spack/crusher/sbatch.sh
+++ b/buildsystem/spack/crusher/sbatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#SBATCH -A CSC359
+#SBATCH -A ENG145
 #SBATCH -p batch
 #SBATCH -t 100
 #SBATCH -N 1

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -1,27 +1,29 @@
 spack:
   specs:
-  - exago@develop%clang@14.0.0-rocm5.2.0-mixed amdgpu_target=gfx90a
+  - exago@develop%clang@16.0.0-rocm5.6.0-mixed amdgpu_target=gfx90a
     ^coinhsl%gcc@12.2.0-mixed
     ^openblas%gcc@12.2.0-mixed
+    ^petsc%clang@16.0.0-rocm5.6.0-mixed target=x86_64
+  - ginkgo@1.7.0%clang@16.0.0-rocm5.6.0-mixed
   view: false
   concretizer:
     unify: when_possible
     reuse: false
   compilers:
   - compiler:
-      spec: clang@14.0.0-rocm5.2.0-mixed
+      spec: clang@16.0.0-rocm5.6.0-mixed
       paths:
-        cc: /opt/rocm-5.2.0/llvm/bin/amdclang
-        cxx: /opt/rocm-5.2.0/llvm/bin/amdclang++
-        f77: /opt/rocm-5.2.0/llvm/bin/amdflang
-        fc: /opt/rocm-5.2.0/llvm/bin/amdflang
+        cc: /opt/rocm-5.6.0/llvm/bin/amdclang
+        cxx: /opt/rocm-5.6.0/llvm/bin/amdclang++
+        f77: /opt/rocm-5.6.0/llvm/bin/amdflang
+        fc: /opt/rocm-5.6.0/llvm/bin/amdflang
       flags: {}
       operating_system: sles15
       target: x86_64
       modules:
       - PrgEnv-gnu-amd
       - cray-mpich/8.1.25
-      - amd-mixed/5.2.0
+      - amd-mixed/5.6.0
       - gcc/12.2.0
       - craype-accel-amd-gfx90a
       - craype-x86-trento
@@ -41,7 +43,7 @@ spack:
       modules:
       - PrgEnv-gnu-amd
       - cray-mpich/8.1.25
-      - amd-mixed/5.2.0
+      - amd-mixed/5.6.0
       - gcc/12.2.0
       - craype-accel-amd-gfx90a
       - craype-x86-trento
@@ -51,15 +53,16 @@ spack:
   packages:
     all:
       compiler:
-      - clang@14.0.0-rocm5.2.0-mixed
+      - clang@16.0.0-rocm5.6.0-mixed
       providers:
         blas: [openblas]
         mpi: [cray-mpich]
-      target: [zen3]
+      target: [x86_64]
     exago:
       require: ~python+raja+hiop+rocm+ipopt
     hiop:
-      require: '@develop+sparse+mpi+raja+rocm+ginkgo+kron'
+      require: +sparse+mpi+raja+rocm~ginkgo+kron
+      version: [develop]
     ipopt:
       require: '@3.12.10~metis+coinhsl~mumps'
     # Pin OpenBlas version for consistent test results.
@@ -71,23 +74,21 @@ spack:
     raja:
       require: ~examples~exercises
       version: [0.14.0]
-    ginkgo:
-      require: '@1.5.0.glu_experimental~openmp'
     coinhsl:
       require: '@2019.05.21'
     magma:
-      require: '@2.6.2'
+      require: '@2.7.2'
     petsc:
       require: ~hypre~superlu-dist~hdf5~metis
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.25 %clang@14.0.0-rocm5.2.0-mixed
+      - spec: cray-mpich@8.1.25 %clang@16.0.0-rocm5.6.0-mixed
         prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
         modules:
         - PrgEnv-gnu-amd
         - cray-mpich/8.1.25
-        - amd-mixed/5.2.0
+        - amd-mixed/5.6.0
         - gcc/12.2.0
         - craype-accel-amd-gfx90a
         - craype-x86-trento
@@ -113,163 +114,163 @@ spack:
     comgr:
       buildable: false
       externals:
-      - spec: comgr@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: comgr@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hip-rocclr:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.2.0
-        prefix: /opt/rocm-5.2.0/hip
+      - spec: hip-rocclr@5.6.0
+        prefix: /opt/rocm-5.6.0/hip
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipblas@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipcub@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipfft@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hipsparse@5.6.0
+        prefix: /opt/rocm-5.6.0/
     miopen-hip:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hip-rocclr@5.6.0
+        prefix: /opt/rocm-5.6.0/
     miopengemm:
       buildable: false
       externals:
-      - spec: miopengemm@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: miopengemm@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rccl@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocblas@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocfft@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-clang-ocl:
       buildable: false
       externals:
-      - spec: rocm-clang-ocl@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-clang-ocl@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-cmake@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-dbgapi@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-debug-agent@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-device-libs@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-gdb@5.6.0
+        prefix: /opt/rocm-5.6.0/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@5.2.0
-        prefix: /opt/rocm-5.2.0/opencl
+      - spec: rocm-opencl@5.6.0
+        prefix: /opt/rocm-5.6.0/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: rocm-smi-lib@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hip:
       buildable: false
       externals:
-      - spec: hip@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@5.2.0
-        prefix: /opt/rocm-5.2.0/llvm
+      - spec: llvm-amdgpu@5.6.0
+        prefix: /opt/rocm-5.6.0/llvm
     hsakmt-roct:
       buildable: false
       externals:
-      - spec: hsakmt-roct@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hsakmt-roct@5.6.0
+        prefix: /opt/rocm-5.6.0/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@5.2.0
-        prefix: /opt/rocm-5.2.0/
+      - spec: hsa-rocr-dev@5.6.0
+        prefix: /opt/rocm-5.6.0/
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@5.2.0
-        prefix: /opt/rocm-5.2.0/roctracer
+      - spec: roctracer-dev-api@5.6.0
+        prefix: /opt/rocm-5.6.0/roctracer
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocprim@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocrand@5.6.0
+        prefix: /opt/rocm-5.6.0
     hiprand:
       buildable: false
       externals:
-      - spec: hiprand@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hiprand@5.6.0
+        prefix: /opt/rocm-5.6.0
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: hipsolver@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocsolver@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocsparse@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocthrust@5.6.0
+        prefix: /opt/rocm-5.6.0
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@5.2.0
-        prefix: /opt/rocm-5.2.0
+      - spec: rocprofiler-dev@5.6.0
+        prefix: /opt/rocm-5.6.0
   config:
     install_tree:
       root: $SPACK_INSTALL


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [x] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [x] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [x] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This MR updates the Spack configuration and the corresponding modules on Frontier to build with rocm/5.6. The modules are build in the project's world-shared directory.
This replaces #89. [Test failures](https://github.com/pnnl/ExaGO/pull/89#issuecomment-1839500807) remain and should be investigated.
