### PR TITLE
Small spack changes to cleanup spack process on HPC Clusters

### DIFF
--- a/buildsystem/spack/deception/env.sh
+++ b/buildsystem/spack/deception/env.sh
@@ -16,6 +16,9 @@ module load cuda/11.4
 module rm openmpi
 module load openmpi/4.1.0mlx5.0
 
+# Print modules for sanity
+module list
+
 # Define environment variables for where spack stores key files
 # For now, SPACK_INSTALL is the path where everything spack related is installed
 # If you want to modify the module install path, edit the spack.yaml manually

--- a/buildsystem/spack/deception/env.sh
+++ b/buildsystem/spack/deception/env.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
+# Just for CI
 source /etc/profile.d/modules.sh
-module purge
 
 # Load system python
-module load python/miniconda3.9
-source /share/apps/python/miniconda3.9/etc/profile.d/conda.sh
+module rm python
+module load python/miniconda3.9 >/dev/null 2>&1
+source /share/apps/python/miniconda3.9/etc/profile.d/conda.sh >/dev/null 2>&1
 
 # Load system modules
+module rm gcc
 module load gcc/9.1.0
+module rm cuda
 module load cuda/11.4
+module rm openmpi
 module load openmpi/4.1.0mlx5.0
 
 # Define environment variables for where spack stores key files

--- a/buildsystem/spack/incline/env.sh
+++ b/buildsystem/spack/incline/env.sh
@@ -8,8 +8,8 @@ module purge
 # MPI module is finnicky on incline
 modules=$(module list 2>&1)
 if echo $modules | grep -q 'openmpi'; then
-  module load gcc/8.4.0
-  module rm openmpi
+	module load gcc/8.4.0
+	module rm openmpi
 fi
 
 # Configure python and other system modules
@@ -19,6 +19,9 @@ module load openmpi/4.1.4
 # This ROCm module inherently uses 8.4.0
 module load rocm/5.3.0
 module load python/3.7.0
+
+# Print out modules for sanity
+module list
 
 # Try forcing behaviour of spack compiler
 export SPACK_CC=$(which gcc)

--- a/buildsystem/spack/load_spack.sh
+++ b/buildsystem/spack/load_spack.sh
@@ -10,7 +10,6 @@ fi
 MY_CLUSTER="${MY_CLUSTER:?MY_CLUSTER is unset. Please set manually.}"
 [[ -z $MY_CLUSTER ]] && return 1
 
-echo "$MY_CLUSTER" | awk '{print tolower($0)}'
 # Use ${var,,} to convert to lower case
 # There must be an existing folder for the cluster
 if [ ! -d "./buildsystem/spack/${MY_CLUSTER}" ]; then

--- a/buildsystem/spack/newell/env.sh
+++ b/buildsystem/spack/newell/env.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
+# Just for CI
 . /etc/profile.d/modules.sh
 
 # Load system python
-module load python/miniconda3.8
-. /share/apps/python/miniconda3.8/etc/profile.d/conda.sh
+module rm python
+module load python/miniconda3.8 >/dev/null 2>&1
+. /share/apps/python/miniconda3.8/etc/profile.d/conda.sh >/dev/null 2>&1
 
 # Load compiler/system modules
+module rm gcc
 module load gcc/8.5.0
+module rm cuda
 module load cuda/11.4
+module rm openmpi
 module load openmpi/4.1.4
+
+# Print modules for sanity
+module list
 
 # Define environment variables for where spack stores key files
 # For now, SPACK_INSTALL is the path where everything spack related is installed


### PR DESCRIPTION
**Merge request type**
- [x] Resolves bug

**Relates to**
- [x] Spack configuration

**This MR updates**
- [x] Spack configuration

**Summary**

No specific issue being addressed here, just some quality of life changes to some of our spack scripts. This makes it so that the spack environment is created in a single line, and that there is no longer a `module purge` that is ran before config is loaded. This is helpful to prevent harmful environment modifications by our scripts where they might be unnecessary.

If these changes are ok, we can extend this to other clusters as needed. Many of the whitespace changes were automatically made by my editor, and we can change / revert as needed. We don't really have any bash linting configuration or developer guidelines surrounding those files...
