### PR TITLE
Update deceptionVariables.sh

### DIFF
--- a/buildsystem/clang-hip/crusherVariables.sh
+++ b/buildsystem/clang-hip/crusherVariables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SRCDIR=${SRCDIR:-$PWD}
+SRCDIR=${SRCDIR:-$PWD}
 
 # Platform specific configuration
 source $SRCDIR/buildsystem/clang-hip/crusher/base.sh

--- a/buildsystem/gcc-cuda/ascentVariables.sh
+++ b/buildsystem/gcc-cuda/ascentVariables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SRCDIR=${SRCDIR:-$PWD}
+SRCDIR=${SRCDIR:-$PWD}
 export MY_CLUSTER=ascent
 
 # Spack modules

--- a/buildsystem/gcc-cuda/deceptionVariables.sh
+++ b/buildsystem/gcc-cuda/deceptionVariables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SRCDIR=${SRCDIR:-$PWD}
+SRCDIR=${SRCDIR:-$PWD}
 
 # Shared platform config
 source $SRCDIR/buildsystem/gcc-cuda/deception/base.sh

--- a/buildsystem/gcc-cuda/newellVariables.sh
+++ b/buildsystem/gcc-cuda/newellVariables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SRCDIR=${SRCDIR:-$PWD}
+SRCDIR=${SRCDIR:-$PWD}
 
 # Shared system configuration
 source $SRCDIR/buildsystem/gcc-cuda/newell/base.sh

--- a/buildsystem/gcc-cuda/summitVariables.sh
+++ b/buildsystem/gcc-cuda/summitVariables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SRCDIR=${SRCDIR:-$PWD}
+SRCDIR=${SRCDIR:-$PWD}
 
 # Shared system configuration
 source $SRCDIR/buildsystem/gcc-cuda/summit/base.sh


### PR DESCRIPTION
**Merge request type**
- [x] Resolves bug


**Relates to**
- [x] CMake build system

**This MR updates**
- [x] Other

**Summary**

When people run our build script from the wrong directory, `SRCDIR` can be configured incorrectly. This makes sure the variable isn't exported and should fix the bug...
