### PR TITLE
Nicholson/frontier worldshared cpe23.12

### DIFF
--- a/buildsystem/clang-hip/crusher/base.sh
+++ b/buildsystem/clang-hip/crusher/base.sh
@@ -6,12 +6,13 @@ export PROJ_DIR=/autofs/nccs-svm1_proj/eng145
 module reset
 
 # System modules
-module load PrgEnv-amd
+module load PrgEnv-gnu-amd
 module load cpe/23.12
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
-module load amd/5.7.1
+module load amd-mixed/5.7.1
 module load rocm/5.7.1
+module load gcc-native/12.3
 module load cray-mpich/8.1.28
 module load libfabric
 

--- a/buildsystem/clang-hip/crusher/base.sh
+++ b/buildsystem/clang-hip/crusher/base.sh
@@ -6,18 +6,19 @@ export PROJ_DIR=/autofs/nccs-svm1_proj/eng145
 module reset
 
 # System modules
-module load PrgEnv-gnu-amd
+module load PrgEnv-amd
+module load cpe/23.12
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
-module load amd-mixed/5.6.0
-module load gcc/12.2.0
-module load cray-mpich/8.1.25
+module load amd/5.7.1
+module load rocm/5.7.1
+module load cray-mpich/8.1.28
 module load libfabric
 
 # Consider changing to $(which clang) as for deception
-export CC=/opt/rocm-5.6.0/llvm/bin/amdclang
-export CXX=/opt/rocm-5.6.0/llvm/bin/amdclang++
-export FC=/opt/rocm-5.6.0/llvm/bin/amdflang
+export CC=/opt/rocm-5.7.1/llvm/bin/amdclang
+export CXX=/opt/rocm-5.7.1/llvm/bin/amdclang++
+export FC=/opt/rocm-5.7.1/llvm/bin/amdflang
 
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DEXAGO_CTEST_LAUNCH_COMMAND='srun'"
 export EXTRA_CMAKE_ARGS="$EXTRA_CMAKE_ARGS -DAMDGPU_TARGETS='gfx90a'"

--- a/buildsystem/spack/crusher/env.sh
+++ b/buildsystem/spack/crusher/env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configure python
-module load cray-python/3.9.12.1 
+module load cray-python/3.11.5
 
 BASE=/lustre/orion/eng145/world-shared/$(whoami)
 

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,107 +1,101 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
-# gmake@=4.4.1%clang@=16.0.0-rocm5.6.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
-module load gmake/4.4.1-clang-16.0.0-rocm5.6.0-mixed-4d3igqq
-# pkgconf@=1.9.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load pkgconf/1.9.5-clang-16.0.0-rocm5.6.0-mixed-3xhjflz
-# nghttp2@=1.57.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load nghttp2/1.57.0-clang-16.0.0-rocm5.6.0-mixed-sdtjvwe
-# ca-certificates-mozilla@=2023-05-30%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
-module load ca-certificates-mozilla/2023-05-30-clang-16.0.0-rocm5.6.0-mixed-b35brx3
-# perl@=5.34.0%clang@=16.0.0-rocm5.6.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
-module load perl/5.34.0-clang-16.0.0-rocm5.6.0-mixed-o4kwhsx
-# zlib-ng@=2.1.6%clang@=16.0.0-rocm5.6.0-mixed+compat+opt build_system=autotools arch=linux-sles15-x86_64
-module load zlib-ng/2.1.6-clang-16.0.0-rocm5.6.0-mixed-k6jftme
-# openssl@=3.2.1%clang@=16.0.0-rocm5.6.0-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
-## module load openssl/3.2.1-clang-16.0.0-rocm5.6.0-mixed-3mhtqmf
-# curl@=8.6.0%clang@=16.0.0-rocm5.6.0-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
-module load curl/8.6.0-clang-16.0.0-rocm5.6.0-mixed-ov7e2ec
-# ncurses@=6.4%clang@=16.0.0-rocm5.6.0-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
-module load ncurses/6.4-clang-16.0.0-rocm5.6.0-mixed-xmy4ha6
-# cmake@=3.20.6%clang@=16.0.0-rocm5.6.0-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
-module load cmake/3.20.6-clang-16.0.0-rocm5.6.0-mixed-cdzi5pg
-# blt@=0.4.1%clang@=16.0.0-rocm5.6.0-mixed build_system=generic arch=linux-sles15-x86_64
-module load blt/0.4.1-clang-16.0.0-rocm5.6.0-mixed-brf75se
-# hip@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=aee7249,c2ee21c,e73e91b arch=linux-sles15-x86_64
-module load hip/5.6.0-clang-16.0.0-rocm5.6.0-mixed-2mz3gxg
-# hsa-rocr-dev@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~asan+image+shared build_system=cmake build_type=Release generator=make patches=9267179 arch=linux-sles15-x86_64
-module load hsa-rocr-dev/5.6.0-clang-16.0.0-rocm5.6.0-mixed-l76bkwj
-# llvm-amdgpu@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=a08bbe1,b66529f,d35aec9 arch=linux-sles15-x86_64
-module load llvm-amdgpu/5.6.0-clang-16.0.0-rocm5.6.0-mixed-dewtyvf
-# camp@=0.2.3%clang@=16.0.0-rocm5.6.0-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=cb9e25b arch=linux-sles15-x86_64
-module load camp/0.2.3-clang-16.0.0-rocm5.6.0-mixed-xikgz56
-# cray-mpich@=8.1.25%clang@=16.0.0-rocm5.6.0-mixed+wrappers build_system=generic arch=linux-sles15-x86_64
-module load cray-mpich/8.1.25-clang-16.0.0-rocm5.6.0-mixed-qr5dmb6
-# gcc-runtime@=12.2.0-mixed%gcc@=12.2.0-mixed build_system=generic arch=linux-sles15-x86_64
-module load gcc-runtime/12.2.0-mixed-gcc-12.2.0-mixed-bzp6esl
-# gmake@=4.4.1%gcc@=12.2.0-mixed~guile build_system=generic arch=linux-sles15-x86_64
-module load gmake/4.4.1-gcc-12.2.0-mixed-w6sfqlw
-# perl@=5.34.0%gcc@=12.2.0-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
-module load perl/5.34.0-gcc-12.2.0-mixed-45ygmu5
-# openblas@=0.3.20%gcc@=12.2.0-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
-module load openblas/0.3.20-gcc-12.2.0-mixed-cjm2rkd
-# coinhsl@=2019.05.21%gcc@=12.2.0-mixed+blas build_system=autotools arch=linux-sles15-x86_64
-module load coinhsl/2019.05.21-gcc-12.2.0-mixed-and6kty
-# hipblas@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=f1b0687 arch=linux-sles15-x86_64
-module load hipblas/5.6.0-clang-16.0.0-rocm5.6.0-mixed-pgkobjo
-# hipsparse@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hipsparse/5.6.0-clang-16.0.0-rocm5.6.0-mixed-ekd6wr5
-# magma@=2.7.2%clang@=16.0.0-rocm5.6.0-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load magma/2.7.2-clang-16.0.0-rocm5.6.0-mixed-b2w675g
-# metis@=5.1.0%clang@=16.0.0-rocm5.6.0-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
-module load metis/5.1.0-clang-16.0.0-rocm5.6.0-mixed-2az7z3w
-# rocprim@=5.6.0%clang@=16.0.0-rocm5.6.0-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load rocprim/5.6.0-clang-16.0.0-rocm5.6.0-mixed-hh2g4wl
-# raja@=0.14.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load raja/0.14.0-clang-16.0.0-rocm5.6.0-mixed-xbpm7ni
-# libiconv@=1.17%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load libiconv/1.17-clang-16.0.0-rocm5.6.0-mixed-naqxaw5
-# diffutils@=3.9%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load diffutils/3.9-clang-16.0.0-rocm5.6.0-mixed-dh5ipjd
-# libsigsegv@=2.14%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load libsigsegv/2.14-clang-16.0.0-rocm5.6.0-mixed-f2emrox
-# m4@=1.4.19%clang@=16.0.0-rocm5.6.0-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
-module load m4/1.4.19-clang-16.0.0-rocm5.6.0-mixed-xemq6xh
-# autoconf@=2.72%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load autoconf/2.72-clang-16.0.0-rocm5.6.0-mixed-7fvtern
-# automake@=1.16.5%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load automake/1.16.5-clang-16.0.0-rocm5.6.0-mixed-3p2ykck
-# findutils@=4.9.0%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools patches=440b954 arch=linux-sles15-x86_64
-module load findutils/4.9.0-clang-16.0.0-rocm5.6.0-mixed-b2j6llu
-# libtool@=2.4.7%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load libtool/2.4.7-clang-16.0.0-rocm5.6.0-mixed-s7mxgfu
-# gmp@=6.2.1%clang@=16.0.0-rocm5.6.0-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
-module load gmp/6.2.1-clang-16.0.0-rocm5.6.0-mixed-3gygkj2
-# autoconf-archive@=2023.02.20%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load autoconf-archive/2023.02.20-clang-16.0.0-rocm5.6.0-mixed-2j34bwo
-# bzip2@=1.0.8%clang@=16.0.0-rocm5.6.0-mixed~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
-module load bzip2/1.0.8-clang-16.0.0-rocm5.6.0-mixed-zmolwma
-# xz@=5.4.6%clang@=16.0.0-rocm5.6.0-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load xz/5.4.6-clang-16.0.0-rocm5.6.0-mixed-heumicj
-# libxml2@=2.10.3%clang@=16.0.0-rocm5.6.0-mixed+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
-module load libxml2/2.10.3-clang-16.0.0-rocm5.6.0-mixed-blh43sg
-# pigz@=2.8%clang@=16.0.0-rocm5.6.0-mixed build_system=makefile arch=linux-sles15-x86_64
-module load pigz/2.8-clang-16.0.0-rocm5.6.0-mixed-4yfazjp
-# zstd@=1.5.5%clang@=16.0.0-rocm5.6.0-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
-module load zstd/1.5.5-clang-16.0.0-rocm5.6.0-mixed-oheyequ
-# tar@=1.34%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools zip=pigz arch=linux-sles15-x86_64
-module load tar/1.34-clang-16.0.0-rocm5.6.0-mixed-pzu4tqg
-# gettext@=0.22.4%clang@=16.0.0-rocm5.6.0-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
-module load gettext/0.22.4-clang-16.0.0-rocm5.6.0-mixed-sqcwu4y
-# texinfo@=7.0.3%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools arch=linux-sles15-x86_64
-module load texinfo/7.0.3-clang-16.0.0-rocm5.6.0-mixed-rodb6i5
-# mpfr@=4.2.1%clang@=16.0.0-rocm5.6.0-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load mpfr/4.2.1-clang-16.0.0-rocm5.6.0-mixed-qyezacq
-# suite-sparse@=5.13.0%clang@=16.0.0-rocm5.6.0-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
-module load suite-sparse/5.13.0-clang-16.0.0-rocm5.6.0-mixed-ezd62mz
-# umpire@=6.0.0%clang@=16.0.0-rocm5.6.0-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
-module load umpire/6.0.0-clang-16.0.0-rocm5.6.0-mixed-gbrp7vf
-# hiop@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hiop/develop-clang-16.0.0-rocm5.6.0-mixed-t6ikxk6
-# ipopt@=3.12.10%clang@=16.0.0-rocm5.6.0-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
-module load ipopt/3.12.10-clang-16.0.0-rocm5.6.0-mixed-7fp33q6
-# python@=3.9.12%clang@=16.0.0-rocm5.6.0-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=0d98e93,4c24573,ebdca64,f2fd060 arch=linux-sles15-x86_64
-module load python/3.9.12-clang-16.0.0-rocm5.6.0-mixed-bn2m2fd
-# petsc@=3.20.4%clang@=16.0.0-rocm5.6.0-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
-module load petsc/3.20.4-clang-16.0.0-rocm5.6.0-mixed-zgcdpbe
-# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-## module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-kqa5be2
+# gmake@=4.3%clang@=17.0.0-rocm5.7.1~guile build_system=generic patches=599f134 arch=linux-sles15-x86_64
+module load gmake/4.3-clang-17.0.0-rocm5.7.1-nddwmha
+# pkgconf@=1.9.5%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load pkgconf/1.9.5-clang-17.0.0-rocm5.7.1-nwo2jra
+# nghttp2@=1.57.0%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load nghttp2/1.57.0-clang-17.0.0-rocm5.7.1-4lexdyk
+# ca-certificates-mozilla@=2023-05-30%clang@=17.0.0-rocm5.7.1 build_system=generic arch=linux-sles15-x86_64
+module load ca-certificates-mozilla/2023-05-30-clang-17.0.0-rocm5.7.1-ndecgeb
+# perl@=5.34.0%clang@=17.0.0-rocm5.7.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+module load perl/5.34.0-clang-17.0.0-rocm5.7.1-5wz23qm
+# zlib-ng@=2.1.6%clang@=17.0.0-rocm5.7.1+compat+new_strategies+opt build_system=autotools arch=linux-sles15-x86_64
+module load zlib-ng/2.1.6-clang-17.0.0-rocm5.7.1-ram6oz7
+# openssl@=3.2.1%clang@=17.0.0-rocm5.7.1~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
+## module load openssl/3.2.1-clang-17.0.0-rocm5.7.1-pdstdgu
+# curl@=8.6.0%clang@=17.0.0-rocm5.7.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
+module load curl/8.6.0-clang-17.0.0-rocm5.7.1-avjuvwe
+# ncurses@=6.4%clang@=17.0.0-rocm5.7.1~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
+module load ncurses/6.4-clang-17.0.0-rocm5.7.1-bkyrvxv
+# cmake@=3.20.6%clang@=17.0.0-rocm5.7.1~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
+module load cmake/3.20.6-clang-17.0.0-rocm5.7.1-3r6do3u
+# blt@=0.4.1%clang@=17.0.0-rocm5.7.1 build_system=generic arch=linux-sles15-x86_64
+module load blt/0.4.1-clang-17.0.0-rocm5.7.1-ob4xxpn
+# hip@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm build_system=cmake build_type=Release generator=make patches=5bb9b0e,7668b2a,aee7249,b589a02,c2ee21c arch=linux-sles15-x86_64
+module load hip/5.7.1-clang-17.0.0-rocm5.7.1-75dn5yy
+# hsa-rocr-dev@=5.7.1%clang@=17.0.0-rocm5.7.1~asan+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hsa-rocr-dev/5.7.1-clang-17.0.0-rocm5.7.1-mizwkrm
+# llvm-amdgpu@=5.7.1%clang@=17.0.0-rocm5.7.1~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=53f9500,9a97712,b66529f arch=linux-sles15-x86_64
+module load llvm-amdgpu/5.7.1-clang-17.0.0-rocm5.7.1-mi32544
+# camp@=0.2.3%clang@=17.0.0-rocm5.7.1~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=cb9e25b arch=linux-sles15-x86_64
+module load camp/0.2.3-clang-17.0.0-rocm5.7.1-c55efcq
+# cray-mpich@=8.1.28%clang@=17.0.0-rocm5.7.1+wrappers build_system=generic arch=linux-sles15-x86_64
+module load cray-mpich/8.1.28-clang-17.0.0-rocm5.7.1-hlzs2oy
+# openblas@=0.3.20%clang@=17.0.0-rocm5.7.1~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9968625,9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
+module load openblas/0.3.20-clang-17.0.0-rocm5.7.1-slikqnh
+# coinhsl@=2019.05.21%clang@=17.0.0-rocm5.7.1+blas build_system=autotools arch=linux-sles15-x86_64
+module load coinhsl/2019.05.21-clang-17.0.0-rocm5.7.1-wkelt3i
+# hipblas@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=f1b0687 arch=linux-sles15-x86_64
+module load hipblas/5.7.1-clang-17.0.0-rocm5.7.1-7dopdxg
+# hipsparse@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipsparse/5.7.1-clang-17.0.0-rocm5.7.1-dl3ghr6
+# magma@=2.7.2%clang@=17.0.0-rocm5.7.1~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load magma/2.7.2-clang-17.0.0-rocm5.7.1-apopwgf
+# metis@=5.1.0%clang@=17.0.0-rocm5.7.1~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
+module load metis/5.1.0-clang-17.0.0-rocm5.7.1-psr5tyz
+# rocprim@=5.7.1%clang@=17.0.0-rocm5.7.1 amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load rocprim/5.7.1-clang-17.0.0-rocm5.7.1-gakrls3
+# raja@=0.14.0%clang@=17.0.0-rocm5.7.1~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load raja/0.14.0-clang-17.0.0-rocm5.7.1-onmgi2d
+# libiconv@=1.17%clang@=17.0.0-rocm5.7.1 build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load libiconv/1.17-clang-17.0.0-rocm5.7.1-hnl6m24
+# diffutils@=3.10%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load diffutils/3.10-clang-17.0.0-rocm5.7.1-enb5vdz
+# libsigsegv@=2.14%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load libsigsegv/2.14-clang-17.0.0-rocm5.7.1-ruhgxlh
+# m4@=1.4.19%clang@=17.0.0-rocm5.7.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
+module load m4/1.4.19-clang-17.0.0-rocm5.7.1-kt4rgm4
+# autoconf@=2.72%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load autoconf/2.72-clang-17.0.0-rocm5.7.1-3znqc65
+# automake@=1.16.5%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load automake/1.16.5-clang-17.0.0-rocm5.7.1-7zcyrz5
+# findutils@=4.9.0%clang@=17.0.0-rocm5.7.1 build_system=autotools patches=440b954 arch=linux-sles15-x86_64
+module load findutils/4.9.0-clang-17.0.0-rocm5.7.1-cqhq5yp
+# libtool@=2.4.7%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load libtool/2.4.7-clang-17.0.0-rocm5.7.1-dxuceh5
+# gmp@=6.2.1%clang@=17.0.0-rocm5.7.1+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
+module load gmp/6.2.1-clang-17.0.0-rocm5.7.1-fism3yk
+# autoconf-archive@=2023.02.20%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load autoconf-archive/2023.02.20-clang-17.0.0-rocm5.7.1-cu5ts4p
+# bzip2@=1.0.8%clang@=17.0.0-rocm5.7.1~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
+module load bzip2/1.0.8-clang-17.0.0-rocm5.7.1-uwso2l7
+# xz@=5.4.6%clang@=17.0.0-rocm5.7.1~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load xz/5.4.6-clang-17.0.0-rocm5.7.1-767bzjj
+# libxml2@=2.10.3%clang@=17.0.0-rocm5.7.1+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
+module load libxml2/2.10.3-clang-17.0.0-rocm5.7.1-gy576lq
+# pigz@=2.8%clang@=17.0.0-rocm5.7.1 build_system=makefile arch=linux-sles15-x86_64
+module load pigz/2.8-clang-17.0.0-rocm5.7.1-xmqkryq
+# zstd@=1.5.5%clang@=17.0.0-rocm5.7.1+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
+module load zstd/1.5.5-clang-17.0.0-rocm5.7.1-pcjm6lw
+# tar@=1.34%clang@=17.0.0-rocm5.7.1 build_system=autotools zip=pigz arch=linux-sles15-x86_64
+module load tar/1.34-clang-17.0.0-rocm5.7.1-uojmtx3
+# gettext@=0.22.4%clang@=17.0.0-rocm5.7.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
+module load gettext/0.22.4-clang-17.0.0-rocm5.7.1-oz3jmnq
+# texinfo@=7.0.3%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
+module load texinfo/7.0.3-clang-17.0.0-rocm5.7.1-4j7pjhb
+# mpfr@=4.2.1%clang@=17.0.0-rocm5.7.1 build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load mpfr/4.2.1-clang-17.0.0-rocm5.7.1-5jbmi3f
+# suite-sparse@=5.13.0%clang@=17.0.0-rocm5.7.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
+module load suite-sparse/5.13.0-clang-17.0.0-rocm5.7.1-cdejlpe
+# umpire@=6.0.0%clang@=17.0.0-rocm5.7.1+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
+module load umpire/6.0.0-clang-17.0.0-rocm5.7.1-s4nlsx5
+# hiop@=develop%clang@=17.0.0-rocm5.7.1~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hiop/develop-clang-17.0.0-rocm5.7.1-nmp3foh
+# ipopt@=3.12.10%clang@=17.0.0-rocm5.7.1+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
+module load ipopt/3.12.10-clang-17.0.0-rocm5.7.1-bqpb4bi
+# python@=3.11.5%clang@=17.0.0-rocm5.7.1+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-sles15-x86_64
+module load python/3.11.5-clang-17.0.0-rocm5.7.1-kmjxg2r
+# petsc@=3.20.4%clang@=17.0.0-rocm5.7.1~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
+module load petsc/3.20.4-clang-17.0.0-rocm5.7.1-7b6bxwi
+# exago@=develop%clang@=17.0.0-rocm5.7.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+## module load exago/develop-clang-17.0.0-rocm5.7.1-vc5kuoe

--- a/buildsystem/spack/crusher/modules/dependencies.sh
+++ b/buildsystem/spack/crusher/modules/dependencies.sh
@@ -1,101 +1,107 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
-# gmake@=4.3%clang@=17.0.0-rocm5.7.1~guile build_system=generic patches=599f134 arch=linux-sles15-x86_64
-module load gmake/4.3-clang-17.0.0-rocm5.7.1-nddwmha
-# pkgconf@=1.9.5%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load pkgconf/1.9.5-clang-17.0.0-rocm5.7.1-nwo2jra
-# nghttp2@=1.57.0%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load nghttp2/1.57.0-clang-17.0.0-rocm5.7.1-4lexdyk
-# ca-certificates-mozilla@=2023-05-30%clang@=17.0.0-rocm5.7.1 build_system=generic arch=linux-sles15-x86_64
-module load ca-certificates-mozilla/2023-05-30-clang-17.0.0-rocm5.7.1-ndecgeb
-# perl@=5.34.0%clang@=17.0.0-rocm5.7.1+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
-module load perl/5.34.0-clang-17.0.0-rocm5.7.1-5wz23qm
-# zlib-ng@=2.1.6%clang@=17.0.0-rocm5.7.1+compat+new_strategies+opt build_system=autotools arch=linux-sles15-x86_64
-module load zlib-ng/2.1.6-clang-17.0.0-rocm5.7.1-ram6oz7
-# openssl@=3.2.1%clang@=17.0.0-rocm5.7.1~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
-## module load openssl/3.2.1-clang-17.0.0-rocm5.7.1-pdstdgu
-# curl@=8.6.0%clang@=17.0.0-rocm5.7.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
-module load curl/8.6.0-clang-17.0.0-rocm5.7.1-avjuvwe
-# ncurses@=6.4%clang@=17.0.0-rocm5.7.1~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
-module load ncurses/6.4-clang-17.0.0-rocm5.7.1-bkyrvxv
-# cmake@=3.20.6%clang@=17.0.0-rocm5.7.1~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
-module load cmake/3.20.6-clang-17.0.0-rocm5.7.1-3r6do3u
-# blt@=0.4.1%clang@=17.0.0-rocm5.7.1 build_system=generic arch=linux-sles15-x86_64
-module load blt/0.4.1-clang-17.0.0-rocm5.7.1-ob4xxpn
-# hip@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm build_system=cmake build_type=Release generator=make patches=5bb9b0e,7668b2a,aee7249,b589a02,c2ee21c arch=linux-sles15-x86_64
-module load hip/5.7.1-clang-17.0.0-rocm5.7.1-75dn5yy
-# hsa-rocr-dev@=5.7.1%clang@=17.0.0-rocm5.7.1~asan+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hsa-rocr-dev/5.7.1-clang-17.0.0-rocm5.7.1-mizwkrm
-# llvm-amdgpu@=5.7.1%clang@=17.0.0-rocm5.7.1~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=53f9500,9a97712,b66529f arch=linux-sles15-x86_64
-module load llvm-amdgpu/5.7.1-clang-17.0.0-rocm5.7.1-mi32544
-# camp@=0.2.3%clang@=17.0.0-rocm5.7.1~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=cb9e25b arch=linux-sles15-x86_64
-module load camp/0.2.3-clang-17.0.0-rocm5.7.1-c55efcq
-# cray-mpich@=8.1.28%clang@=17.0.0-rocm5.7.1+wrappers build_system=generic arch=linux-sles15-x86_64
-module load cray-mpich/8.1.28-clang-17.0.0-rocm5.7.1-hlzs2oy
-# openblas@=0.3.20%clang@=17.0.0-rocm5.7.1~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9968625,9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
-module load openblas/0.3.20-clang-17.0.0-rocm5.7.1-slikqnh
-# coinhsl@=2019.05.21%clang@=17.0.0-rocm5.7.1+blas build_system=autotools arch=linux-sles15-x86_64
-module load coinhsl/2019.05.21-clang-17.0.0-rocm5.7.1-wkelt3i
-# hipblas@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=f1b0687 arch=linux-sles15-x86_64
-module load hipblas/5.7.1-clang-17.0.0-rocm5.7.1-7dopdxg
-# hipsparse@=5.7.1%clang@=17.0.0-rocm5.7.1~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hipsparse/5.7.1-clang-17.0.0-rocm5.7.1-dl3ghr6
-# magma@=2.7.2%clang@=17.0.0-rocm5.7.1~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load magma/2.7.2-clang-17.0.0-rocm5.7.1-apopwgf
-# metis@=5.1.0%clang@=17.0.0-rocm5.7.1~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
-module load metis/5.1.0-clang-17.0.0-rocm5.7.1-psr5tyz
-# rocprim@=5.7.1%clang@=17.0.0-rocm5.7.1 amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load rocprim/5.7.1-clang-17.0.0-rocm5.7.1-gakrls3
-# raja@=0.14.0%clang@=17.0.0-rocm5.7.1~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load raja/0.14.0-clang-17.0.0-rocm5.7.1-onmgi2d
-# libiconv@=1.17%clang@=17.0.0-rocm5.7.1 build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load libiconv/1.17-clang-17.0.0-rocm5.7.1-hnl6m24
-# diffutils@=3.10%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load diffutils/3.10-clang-17.0.0-rocm5.7.1-enb5vdz
-# libsigsegv@=2.14%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load libsigsegv/2.14-clang-17.0.0-rocm5.7.1-ruhgxlh
-# m4@=1.4.19%clang@=17.0.0-rocm5.7.1+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
-module load m4/1.4.19-clang-17.0.0-rocm5.7.1-kt4rgm4
-# autoconf@=2.72%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load autoconf/2.72-clang-17.0.0-rocm5.7.1-3znqc65
-# automake@=1.16.5%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load automake/1.16.5-clang-17.0.0-rocm5.7.1-7zcyrz5
-# findutils@=4.9.0%clang@=17.0.0-rocm5.7.1 build_system=autotools patches=440b954 arch=linux-sles15-x86_64
-module load findutils/4.9.0-clang-17.0.0-rocm5.7.1-cqhq5yp
-# libtool@=2.4.7%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load libtool/2.4.7-clang-17.0.0-rocm5.7.1-dxuceh5
-# gmp@=6.2.1%clang@=17.0.0-rocm5.7.1+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
-module load gmp/6.2.1-clang-17.0.0-rocm5.7.1-fism3yk
-# autoconf-archive@=2023.02.20%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load autoconf-archive/2023.02.20-clang-17.0.0-rocm5.7.1-cu5ts4p
-# bzip2@=1.0.8%clang@=17.0.0-rocm5.7.1~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
-module load bzip2/1.0.8-clang-17.0.0-rocm5.7.1-uwso2l7
-# xz@=5.4.6%clang@=17.0.0-rocm5.7.1~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load xz/5.4.6-clang-17.0.0-rocm5.7.1-767bzjj
-# libxml2@=2.10.3%clang@=17.0.0-rocm5.7.1+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
-module load libxml2/2.10.3-clang-17.0.0-rocm5.7.1-gy576lq
-# pigz@=2.8%clang@=17.0.0-rocm5.7.1 build_system=makefile arch=linux-sles15-x86_64
-module load pigz/2.8-clang-17.0.0-rocm5.7.1-xmqkryq
-# zstd@=1.5.5%clang@=17.0.0-rocm5.7.1+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
-module load zstd/1.5.5-clang-17.0.0-rocm5.7.1-pcjm6lw
-# tar@=1.34%clang@=17.0.0-rocm5.7.1 build_system=autotools zip=pigz arch=linux-sles15-x86_64
-module load tar/1.34-clang-17.0.0-rocm5.7.1-uojmtx3
-# gettext@=0.22.4%clang@=17.0.0-rocm5.7.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
-module load gettext/0.22.4-clang-17.0.0-rocm5.7.1-oz3jmnq
-# texinfo@=7.0.3%clang@=17.0.0-rocm5.7.1 build_system=autotools arch=linux-sles15-x86_64
-module load texinfo/7.0.3-clang-17.0.0-rocm5.7.1-4j7pjhb
-# mpfr@=4.2.1%clang@=17.0.0-rocm5.7.1 build_system=autotools libs=shared,static arch=linux-sles15-x86_64
-module load mpfr/4.2.1-clang-17.0.0-rocm5.7.1-5jbmi3f
-# suite-sparse@=5.13.0%clang@=17.0.0-rocm5.7.1~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
-module load suite-sparse/5.13.0-clang-17.0.0-rocm5.7.1-cdejlpe
-# umpire@=6.0.0%clang@=17.0.0-rocm5.7.1+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
-module load umpire/6.0.0-clang-17.0.0-rocm5.7.1-s4nlsx5
-# hiop@=develop%clang@=17.0.0-rocm5.7.1~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load hiop/develop-clang-17.0.0-rocm5.7.1-nmp3foh
-# ipopt@=3.12.10%clang@=17.0.0-rocm5.7.1+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
-module load ipopt/3.12.10-clang-17.0.0-rocm5.7.1-bqpb4bi
-# python@=3.11.5%clang@=17.0.0-rocm5.7.1+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-sles15-x86_64
-module load python/3.11.5-clang-17.0.0-rocm5.7.1-kmjxg2r
-# petsc@=3.20.4%clang@=17.0.0-rocm5.7.1~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
-module load petsc/3.20.4-clang-17.0.0-rocm5.7.1-7b6bxwi
-# exago@=develop%clang@=17.0.0-rocm5.7.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-## module load exago/develop-clang-17.0.0-rocm5.7.1-vc5kuoe
+# gmake@=4.3%clang@=17.0.0-rocm5.7.1-mixed~guile build_system=generic patches=599f134 arch=linux-sles15-x86_64
+module load gmake/4.3-clang-17.0.0-rocm5.7.1-mixed-x2fskbm
+# pkgconf@=1.9.5%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load pkgconf/1.9.5-clang-17.0.0-rocm5.7.1-mixed-m4urn4t
+# nghttp2@=1.57.0%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load nghttp2/1.57.0-clang-17.0.0-rocm5.7.1-mixed-rrynpn7
+# ca-certificates-mozilla@=2023-05-30%clang@=17.0.0-rocm5.7.1-mixed build_system=generic arch=linux-sles15-x86_64
+module load ca-certificates-mozilla/2023-05-30-clang-17.0.0-rocm5.7.1-mixed-lhn5rvo
+# perl@=5.34.0%clang@=17.0.0-rocm5.7.1-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+module load perl/5.34.0-clang-17.0.0-rocm5.7.1-mixed-7yifv3t
+# zlib-ng@=2.1.6%clang@=17.0.0-rocm5.7.1-mixed+compat+new_strategies+opt build_system=autotools arch=linux-sles15-x86_64
+module load zlib-ng/2.1.6-clang-17.0.0-rocm5.7.1-mixed-menugrv
+# openssl@=3.2.1%clang@=17.0.0-rocm5.7.1-mixed~docs+shared build_system=generic certs=mozilla arch=linux-sles15-x86_64
+## module load openssl/3.2.1-clang-17.0.0-rocm5.7.1-mixed-3ha6f2t
+# curl@=8.6.0%clang@=17.0.0-rocm5.7.1-mixed~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-sles15-x86_64
+module load curl/8.6.0-clang-17.0.0-rocm5.7.1-mixed-cq4gjom
+# ncurses@=6.4%clang@=17.0.0-rocm5.7.1-mixed~symlinks+termlib abi=none build_system=autotools arch=linux-sles15-x86_64
+module load ncurses/6.4-clang-17.0.0-rocm5.7.1-mixed-5fu3rph
+# cmake@=3.20.6%clang@=17.0.0-rocm5.7.1-mixed~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-sles15-x86_64
+module load cmake/3.20.6-clang-17.0.0-rocm5.7.1-mixed-tsnlb3w
+# blt@=0.4.1%clang@=17.0.0-rocm5.7.1-mixed build_system=generic arch=linux-sles15-x86_64
+module load blt/0.4.1-clang-17.0.0-rocm5.7.1-mixed-yv7w5ka
+# hip@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed~cuda+rocm build_system=cmake build_type=Release generator=make patches=5bb9b0e,7668b2a,aee7249,b589a02,c2ee21c arch=linux-sles15-x86_64
+module load hip/5.7.1-clang-17.0.0-rocm5.7.1-mixed-aokghsk
+# hsa-rocr-dev@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed~asan+image+shared build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hsa-rocr-dev/5.7.1-clang-17.0.0-rocm5.7.1-mixed-4cjwtst
+# llvm-amdgpu@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed~link_llvm_dylib~llvm_dylib+rocm-device-libs build_system=cmake build_type=Release generator=ninja patches=53f9500,9a97712,b66529f arch=linux-sles15-x86_64
+module load llvm-amdgpu/5.7.1-clang-17.0.0-rocm5.7.1-mixed-4xxmwvj
+# camp@=0.2.3%clang@=17.0.0-rocm5.7.1-mixed~cuda~ipo~openmp+rocm~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make patches=cb9e25b arch=linux-sles15-x86_64
+module load camp/0.2.3-clang-17.0.0-rocm5.7.1-mixed-s4wguwz
+# cray-mpich@=8.1.28%clang@=17.0.0-rocm5.7.1-mixed+wrappers build_system=generic arch=linux-sles15-x86_64
+module load cray-mpich/8.1.28-clang-17.0.0-rocm5.7.1-mixed-i3f7um4
+# gcc-runtime@=12.3-mixed%gcc@=12.3-mixed build_system=generic arch=linux-sles15-x86_64
+module load gcc-runtime/12.3-mixed-gcc-12.3-mixed-mu6frky
+## gmake@=4.3%gcc@=12.3-mixed~guile build_system=generic patches=599f134 arch=linux-sles15-x86_64
+#module load gmake/4.3-gcc-12.3-mixed-xell4pg
+## perl@=5.34.0%gcc@=12.3-mixed+cpanm+opcode+open+shared+threads build_system=generic arch=linux-sles15-x86_64
+#module load perl/5.34.0-gcc-12.3-mixed-ukbfqpz
+# openblas@=0.3.20%gcc@=12.3-mixed~bignuma~consistent_fpcsr~ilp64+locking+pic+shared build_system=makefile patches=9f12903 symbol_suffix=none threads=none arch=linux-sles15-x86_64
+module load openblas/0.3.20-gcc-12.3-mixed-7iowws6
+# coinhsl@=2019.05.21%gcc@=12.3-mixed+blas build_system=autotools arch=linux-sles15-x86_64
+module load coinhsl/2019.05.21-gcc-12.3-mixed-4re5qz3
+# hipblas@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make patches=f1b0687 arch=linux-sles15-x86_64
+module load hipblas/5.7.1-clang-17.0.0-rocm5.7.1-mixed-majtcms
+# hipsparse@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed~cuda+rocm amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hipsparse/5.7.1-clang-17.0.0-rocm5.7.1-mixed-mr2uw2o
+# magma@=2.7.2%clang@=17.0.0-rocm5.7.1-mixed~cuda+fortran~ipo+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load magma/2.7.2-clang-17.0.0-rocm5.7.1-mixed-d6z2a7t
+# metis@=5.1.0%clang@=17.0.0-rocm5.7.1-mixed~gdb~int64~ipo~real64+shared build_system=cmake build_type=Release generator=make patches=4991da9,93a7903 arch=linux-sles15-x86_64
+module load metis/5.1.0-clang-17.0.0-rocm5.7.1-mixed-466rdfs
+# rocprim@=5.7.1%clang@=17.0.0-rocm5.7.1-mixed amdgpu_target=auto build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load rocprim/5.7.1-clang-17.0.0-rocm5.7.1-mixed-eigcftr
+# raja@=0.14.0%clang@=17.0.0-rocm5.7.1-mixed~cuda~examples~exercises~ipo~openmp~plugins+rocm+shared~tests amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load raja/0.14.0-clang-17.0.0-rocm5.7.1-mixed-6yzko55
+# libiconv@=1.17%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load libiconv/1.17-clang-17.0.0-rocm5.7.1-mixed-xa3wi7t
+# diffutils@=3.10%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load diffutils/3.10-clang-17.0.0-rocm5.7.1-mixed-7v327yj
+# libsigsegv@=2.14%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libsigsegv/2.14-clang-17.0.0-rocm5.7.1-mixed-qa6g3ep
+# m4@=1.4.19%clang@=17.0.0-rocm5.7.1-mixed+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-sles15-x86_64
+module load m4/1.4.19-clang-17.0.0-rocm5.7.1-mixed-mmkqsk5
+# autoconf@=2.72%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load autoconf/2.72-clang-17.0.0-rocm5.7.1-mixed-3xud5lx
+# automake@=1.16.5%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load automake/1.16.5-clang-17.0.0-rocm5.7.1-mixed-fm7gg6r
+# findutils@=4.9.0%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools patches=440b954 arch=linux-sles15-x86_64
+module load findutils/4.9.0-clang-17.0.0-rocm5.7.1-mixed-ks25vfq
+# libtool@=2.4.7%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load libtool/2.4.7-clang-17.0.0-rocm5.7.1-mixed-hdagdfy
+# gmp@=6.2.1%clang@=17.0.0-rocm5.7.1-mixed+cxx build_system=autotools libs=shared,static patches=69ad2e2 arch=linux-sles15-x86_64
+module load gmp/6.2.1-clang-17.0.0-rocm5.7.1-mixed-ypvpkcj
+# autoconf-archive@=2023.02.20%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load autoconf-archive/2023.02.20-clang-17.0.0-rocm5.7.1-mixed-badlwxr
+# bzip2@=1.0.8%clang@=17.0.0-rocm5.7.1-mixed~debug~pic+shared build_system=generic arch=linux-sles15-x86_64
+module load bzip2/1.0.8-clang-17.0.0-rocm5.7.1-mixed-fcspibr
+# xz@=5.4.6%clang@=17.0.0-rocm5.7.1-mixed~pic build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load xz/5.4.6-clang-17.0.0-rocm5.7.1-mixed-lrxwsek
+# libxml2@=2.10.3%clang@=17.0.0-rocm5.7.1-mixed+pic~python+shared build_system=autotools arch=linux-sles15-x86_64
+module load libxml2/2.10.3-clang-17.0.0-rocm5.7.1-mixed-e6fl67c
+# pigz@=2.8%clang@=17.0.0-rocm5.7.1-mixed build_system=makefile arch=linux-sles15-x86_64
+module load pigz/2.8-clang-17.0.0-rocm5.7.1-mixed-gzgnvtm
+# zstd@=1.5.5%clang@=17.0.0-rocm5.7.1-mixed+programs build_system=makefile compression=none libs=shared,static arch=linux-sles15-x86_64
+module load zstd/1.5.5-clang-17.0.0-rocm5.7.1-mixed-cvopzgs
+# tar@=1.34%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools zip=pigz arch=linux-sles15-x86_64
+module load tar/1.34-clang-17.0.0-rocm5.7.1-mixed-lzhjsn2
+# gettext@=0.22.4%clang@=17.0.0-rocm5.7.1-mixed+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-sles15-x86_64
+module load gettext/0.22.4-clang-17.0.0-rocm5.7.1-mixed-mmpz2s4
+# texinfo@=7.0.3%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools arch=linux-sles15-x86_64
+module load texinfo/7.0.3-clang-17.0.0-rocm5.7.1-mixed-gcudjaq
+# mpfr@=4.2.1%clang@=17.0.0-rocm5.7.1-mixed build_system=autotools libs=shared,static arch=linux-sles15-x86_64
+module load mpfr/4.2.1-clang-17.0.0-rocm5.7.1-mixed-5kolmk3
+# suite-sparse@=5.13.0%clang@=17.0.0-rocm5.7.1-mixed~cuda~graphblas~openmp+pic build_system=generic arch=linux-sles15-x86_64
+module load suite-sparse/5.13.0-clang-17.0.0-rocm5.7.1-mixed-jk4j4xm
+# umpire@=6.0.0%clang@=17.0.0-rocm5.7.1-mixed+c~cuda~device_alloc~deviceconst~examples~fortran~ipo~numa~openmp+rocm+shared amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make tests=none arch=linux-sles15-x86_64
+module load umpire/6.0.0-clang-17.0.0-rocm5.7.1-mixed-dfwqrzx
+# hiop@=develop%clang@=17.0.0-rocm5.7.1-mixed~cuda~deepchecking~ginkgo~ipo~jsrun+kron+mpi+raja+rocm~shared+sparse amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load hiop/develop-clang-17.0.0-rocm5.7.1-mixed-5rqwq45
+# ipopt@=3.12.10%clang@=17.0.0-rocm5.7.1-mixed+coinhsl~debug~metis~mumps build_system=autotools arch=linux-sles15-x86_64
+module load ipopt/3.12.10-clang-17.0.0-rocm5.7.1-mixed-2zdjszo
+# python@=3.11.5%clang@=17.0.0-rocm5.7.1-mixed+bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-sles15-x86_64
+module load python/3.11.5-clang-17.0.0-rocm5.7.1-mixed-ubwwl7x
+# petsc@=3.20.4%clang@=17.0.0-rocm5.7.1-mixed~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-x86_64
+module load petsc/3.20.4-clang-17.0.0-rocm5.7.1-mixed-2btkvwy
+# exago@=develop%clang@=17.0.0-rocm5.7.1-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+## module load exago/develop-clang-17.0.0-rocm5.7.1-mixed-6l3vqyp

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
-# exago@=develop%clang@=16.0.0-rocm5.6.0-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load exago/develop-clang-16.0.0-rocm5.6.0-mixed-kqa5be2
+# exago@=develop%clang@=17.0.0-rocm5.7.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load exago/develop-clang-17.0.0-rocm5.7.1-vc5kuoe

--- a/buildsystem/spack/crusher/modules/exago.sh
+++ b/buildsystem/spack/crusher/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/eng145/world-shared/spack-install/modules/linux-sles15-x86_64
-# exago@=develop%clang@=17.0.0-rocm5.7.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
-module load exago/develop-clang-17.0.0-rocm5.7.1-vc5kuoe
+# exago@=develop%clang@=17.0.0-rocm5.7.1-mixed~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release generator=make arch=linux-sles15-x86_64
+module load exago/develop-clang-17.0.0-rocm5.7.1-mixed-6l3vqyp

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -1,14 +1,16 @@
 spack:
   specs:
-  - exago@develop%clang@17.0.0-rocm5.7.1 amdgpu_target=gfx90a
-    ^petsc%clang@17.0.0-rocm5.7.1 target=x86_64
+  - exago@develop%clang@17.0.0-rocm5.7.1-mixed amdgpu_target=gfx90a
+    ^coinhsl%gcc@12.3-mixed
+    ^openblas%gcc@12.3-mixed
+    ^petsc%clang@17.0.0-rocm5.7.1-mixed target=x86_64
   view: false
   concretizer:
     unify: when_possible
     reuse: false
   compilers:
   - compiler:
-      spec: clang@17.0.0-rocm5.7.1
+      spec: clang@17.0.0-rocm5.7.1-mixed
       paths:
         cc: /opt/rocm-5.7.1/llvm/bin/amdclang
         cxx: /opt/rocm-5.7.1/llvm/bin/amdclang++
@@ -18,10 +20,32 @@ spack:
       operating_system: sles15
       target: x86_64
       modules:
-      - PrgEnv-amd
+      - PrgEnv-gnu-amd
       - cray-mpich/8.1.28
-      - amd/5.7.1
+      - amd-mixed/5.7.1
       - rocm/5.7.1
+      - gcc-native/12.3
+      - craype-accel-amd-gfx90a
+      - craype-x86-trento
+      - libfabric
+      environment: {}
+      extra_rpaths: []
+  - compiler:
+      spec: gcc@12.3-mixed
+      paths:
+        cc: /opt/cray/pe/gcc-native/12/bin/gcc
+        cxx: /opt/cray/pe/gcc-native/12/bin/g++
+        f77: /opt/cray/pe/gcc-native/12/bin/gfortran
+        fc: /opt/cray/pe/gcc-native/12/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: x86_64
+      modules:
+      - PrgEnv-gnu-amd
+      - cray-mpich/8.1.28
+      - amd-mixed/5.7.1
+      - rocm/5.7.1
+      - gcc-native/12.3
       - craype-accel-amd-gfx90a
       - craype-x86-trento
       - libfabric
@@ -30,7 +54,7 @@ spack:
   packages:
     all:
       compiler:
-      - clang@17.0.0-rocm5.7.1
+      - clang@17.0.0-rocm5.7.1-mixed
       providers:
         blas: [openblas]
         mpi: [cray-mpich]
@@ -60,13 +84,15 @@ spack:
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.28 %clang@17.0.0-rocm5.7.1
-        prefix: /opt/cray/pe/mpich/8.1.28/ofi/amd/5.0
+      - spec: cray-mpich@8.1.28 %clang@17.0.0-rocm5.7.1-mixed
+        prefix: /opt/cray/pe/mpich/8.1.28/ofi/gnu/12.3
         modules:
-        - PrgEnv-amd
+        - PrgEnv-gnu-amd
+        - cpe/23.12
         - cray-mpich/8.1.28
-        - amd/5.7.1
+        - amd-mixed/5.7.1
         - rocm/5.7.1
+        - gcc-native/12.3
         - craype-accel-amd-gfx90a
         - craype-x86-trento
         - libfabric

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -1,50 +1,27 @@
 spack:
   specs:
-  - exago@develop%clang@16.0.0-rocm5.6.0-mixed amdgpu_target=gfx90a
-    ^coinhsl%gcc@12.2.0-mixed
-    ^openblas%gcc@12.2.0-mixed
-    ^petsc%clang@16.0.0-rocm5.6.0-mixed target=x86_64
-  - ginkgo@1.7.0%clang@16.0.0-rocm5.6.0-mixed
+  - exago@develop%clang@17.0.0-rocm5.7.1 amdgpu_target=gfx90a
+    ^petsc%clang@17.0.0-rocm5.7.1 target=x86_64
   view: false
   concretizer:
     unify: when_possible
     reuse: false
   compilers:
   - compiler:
-      spec: clang@16.0.0-rocm5.6.0-mixed
+      spec: clang@17.0.0-rocm5.7.1
       paths:
-        cc: /opt/rocm-5.6.0/llvm/bin/amdclang
-        cxx: /opt/rocm-5.6.0/llvm/bin/amdclang++
-        f77: /opt/rocm-5.6.0/llvm/bin/amdflang
-        fc: /opt/rocm-5.6.0/llvm/bin/amdflang
+        cc: /opt/rocm-5.7.1/llvm/bin/amdclang
+        cxx: /opt/rocm-5.7.1/llvm/bin/amdclang++
+        f77: /opt/rocm-5.7.1/llvm/bin/amdflang
+        fc: /opt/rocm-5.7.1/llvm/bin/amdflang
       flags: {}
       operating_system: sles15
       target: x86_64
       modules:
-      - PrgEnv-gnu-amd
-      - cray-mpich/8.1.25
-      - amd-mixed/5.6.0
-      - gcc/12.2.0
-      - craype-accel-amd-gfx90a
-      - craype-x86-trento
-      - libfabric
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: gcc@12.2.0-mixed
-      paths:
-        cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
-        cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
-        f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-        fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-      flags: {}
-      operating_system: sles15
-      target: x86_64
-      modules:
-      - PrgEnv-gnu-amd
-      - cray-mpich/8.1.25
-      - amd-mixed/5.6.0
-      - gcc/12.2.0
+      - PrgEnv-amd
+      - cray-mpich/8.1.28
+      - amd/5.7.1
+      - rocm/5.7.1
       - craype-accel-amd-gfx90a
       - craype-x86-trento
       - libfabric
@@ -53,7 +30,7 @@ spack:
   packages:
     all:
       compiler:
-      - clang@16.0.0-rocm5.6.0-mixed
+      - clang@17.0.0-rocm5.7.1
       providers:
         blas: [openblas]
         mpi: [cray-mpich]
@@ -83,21 +60,21 @@ spack:
     cray-mpich:
       buildable: false
       externals:
-      - spec: cray-mpich@8.1.25 %clang@16.0.0-rocm5.6.0-mixed
-        prefix: /opt/cray/pe/mpich/8.1.25/ofi/gnu/9.1
+      - spec: cray-mpich@8.1.28 %clang@17.0.0-rocm5.7.1
+        prefix: /opt/cray/pe/mpich/8.1.28/ofi/amd/5.0
         modules:
-        - PrgEnv-gnu-amd
-        - cray-mpich/8.1.25
-        - amd-mixed/5.6.0
-        - gcc/12.2.0
+        - PrgEnv-amd
+        - cray-mpich/8.1.28
+        - amd/5.7.1
+        - rocm/5.7.1
         - craype-accel-amd-gfx90a
         - craype-x86-trento
         - libfabric
     python:
       externals:
-      - spec: python@3.9.12
+      - spec: python@3.11.5
         modules:
-        - cray-python/3.9.12.1
+        - cray-python/3.11.5
       buildable: false
     perl:
       externals:
@@ -111,166 +88,172 @@ spack:
       - spec: libfabric@1.15.2.0
         modules:
         - libfabric/1.15.2.0
+    gmake:
+      buildable: false
+      externals:
+      - spec: gmake@4.3
+        modules:
+        - gmake/4.3
     comgr:
       buildable: false
       externals:
-      - spec: comgr@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: comgr@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hip-rocclr:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.6.0
-        prefix: /opt/rocm-5.6.0/hip
+      - spec: hip-rocclr@5.7.1
+        prefix: /opt/rocm-5.7.1/hip
     hipblas:
       buildable: false
       externals:
-      - spec: hipblas@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hipblas@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hipcub@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hipfft:
       buildable: false
       externals:
-      - spec: hipfft@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hipfft@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hipsparse:
       buildable: false
       externals:
-      - spec: hipsparse@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hipsparse@5.7.1
+        prefix: /opt/rocm-5.7.1/
     miopen-hip:
       buildable: false
       externals:
-      - spec: hip-rocclr@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hip-rocclr@5.7.1
+        prefix: /opt/rocm-5.7.1/
     miopengemm:
       buildable: false
       externals:
-      - spec: miopengemm@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: miopengemm@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rccl:
       buildable: false
       externals:
-      - spec: rccl@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rccl@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocblas:
       buildable: false
       externals:
-      - spec: rocblas@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocblas@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocfft:
       buildable: false
       externals:
-      - spec: rocfft@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocfft@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-clang-ocl:
       buildable: false
       externals:
-      - spec: rocm-clang-ocl@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-clang-ocl@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-cmake:
       buildable: false
       externals:
-      - spec: rocm-cmake@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-cmake@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-dbgapi:
       buildable: false
       externals:
-      - spec: rocm-dbgapi@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-dbgapi@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-debug-agent:
       buildable: false
       externals:
-      - spec: rocm-debug-agent@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-debug-agent@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-device-libs:
       buildable: false
       externals:
-      - spec: rocm-device-libs@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-device-libs@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-gdb:
       buildable: false
       externals:
-      - spec: rocm-gdb@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-gdb@5.7.1
+        prefix: /opt/rocm-5.7.1/
     rocm-opencl:
       buildable: false
       externals:
-      - spec: rocm-opencl@5.6.0
-        prefix: /opt/rocm-5.6.0/opencl
+      - spec: rocm-opencl@5.7.1
+        prefix: /opt/rocm-5.7.1/opencl
     rocm-smi-lib:
       buildable: false
       externals:
-      - spec: rocm-smi-lib@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: rocm-smi-lib@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hip:
       buildable: false
       externals:
-      - spec: hip@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: hip@5.7.1
+        prefix: /opt/rocm-5.7.1
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@5.6.0
-        prefix: /opt/rocm-5.6.0/llvm
+      - spec: llvm-amdgpu@5.7.1
+        prefix: /opt/rocm-5.7.1/llvm
     hsakmt-roct:
       buildable: false
       externals:
-      - spec: hsakmt-roct@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hsakmt-roct@5.7.1
+        prefix: /opt/rocm-5.7.1/
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@5.6.0
-        prefix: /opt/rocm-5.6.0/
+      - spec: hsa-rocr-dev@5.7.1
+        prefix: /opt/rocm-5.7.1/
     roctracer-dev-api:
       buildable: false
       externals:
-      - spec: roctracer-dev-api@5.6.0
-        prefix: /opt/rocm-5.6.0/roctracer
+      - spec: roctracer-dev-api@5.7.1
+        prefix: /opt/rocm-5.7.1/roctracer
     rocprim:
       buildable: false
       externals:
-      - spec: rocprim@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocprim@5.7.1
+        prefix: /opt/rocm-5.7.1
     rocrand:
       buildable: false
       externals:
-      - spec: rocrand@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocrand@5.7.1
+        prefix: /opt/rocm-5.7.1
     hiprand:
       buildable: false
       externals:
-      - spec: hiprand@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: hiprand@5.7.1
+        prefix: /opt/rocm-5.7.1
     hipsolver:
       buildable: false
       externals:
-      - spec: hipsolver@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: hipsolver@5.7.1
+        prefix: /opt/rocm-5.7.1
     rocsolver:
       buildable: false
       externals:
-      - spec: rocsolver@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocsolver@5.7.1
+        prefix: /opt/rocm-5.7.1
     rocsparse:
       buildable: false
       externals:
-      - spec: rocsparse@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocsparse@5.7.1
+        prefix: /opt/rocm-5.7.1
     rocthrust:
       buildable: false
       externals:
-      - spec: rocthrust@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocthrust@5.7.1
+        prefix: /opt/rocm-5.7.1
     rocprofiler-dev:
       buildable: false
       externals:
-      - spec: rocprofiler-dev@5.6.0
-        prefix: /opt/rocm-5.6.0
+      - spec: rocprofiler-dev@5.7.1
+        prefix: /opt/rocm-5.7.1
   config:
     install_tree:
       root: $SPACK_INSTALL

--- a/buildsystem/spack/crusher/spack.yaml
+++ b/buildsystem/spack/crusher/spack.yaml
@@ -4,6 +4,7 @@ spack:
     ^coinhsl%gcc@12.3-mixed
     ^openblas%gcc@12.3-mixed
     ^petsc%clang@17.0.0-rocm5.7.1-mixed target=x86_64
+  - ginkgo@1.7.0%clang@17.0.0-rocm5.7.1-mixed
   view: false
   concretizer:
     unify: when_possible

--- a/viz/backend/sqlchain.py
+++ b/viz/backend/sqlchain.py
@@ -9,7 +9,7 @@ from sqlalchemy import text
 
 def sqlchain(input_text):
     llm = ChatOpenAI(openai_api_key=config.openai_key,
-                 model_name="gpt-3.5-turbo", temperature=0, verbose=True)
+                     model_name="gpt-3.5-turbo", temperature=0, verbose=True)
     db = SQLDatabase.from_uri(
         f"postgresql+psycopg2://postgres:{config.sql_key}@localhost:5432/{config.database_name}")
     mydb = sqldb.create_engine(


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [x] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [x] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**
Previously built ExaGO dependencies on Frontier no longer work after an update to the system software environment. This PR uses a more recent programming environment with the appropriate module loaded. 

I documented test failures (similar to previous observations in #89) in issue #152.