### PR TITLE
Update of HiOp option names

### DIFF
--- a/options/hiop.options
+++ b/options/hiop.options
@@ -1,5 +1,5 @@
-#dualsUpdateType linear
-#dualsInitialization zero
+#duals_update_type linear
+#duals_init zero
 
 #Hessian analytical_exact
 #KKTLinsys auto

--- a/src/opflow/solver/hiop/opflow_hiopsparse.cpp
+++ b/src/opflow/solver/hiop/opflow_hiopsparse.cpp
@@ -651,8 +651,8 @@ PetscErrorCode OPFLOWSolverSetUp_HIOPSPARSE(OPFLOW opflow) {
   // hiop->sp->options->SetNumericValue("fixed_var_perturb",1.0e-6);
   // hiop->sp->options->SetStringValue("mem_space","host");
 
-  hiop->sp->options->SetStringValue("dualsUpdateType", "linear");
-  hiop->sp->options->SetStringValue("dualsInitialization", "zero");
+  hiop->sp->options->SetStringValue("duals_update_type", "linear");
+  hiop->sp->options->SetStringValue("duals_init", "zero");
   hiop->sp->options->SetStringValue("fixed_var", "relax");
   hiop->sp->options->SetStringValue("Hessian", "analytical_exact");
   hiop->sp->options->SetStringValue("KKTLinsys", "xdycyd");

--- a/src/opflow/solver/hiop/opflow_hiopsparsegpu.cpp
+++ b/src/opflow/solver/hiop/opflow_hiopsparsegpu.cpp
@@ -380,7 +380,6 @@ PetscErrorCode OPFLOWSolverSetUp_HIOPSPARSEGPU(OPFLOW opflow) {
   hiop->sp->options->SetStringValue("mem_space", "device");
   hiop->sp->options->SetStringValue("compute_mode", "gpu");
 
-  hiop->sp->options->SetStringValue("dualsInitialization", "zero");
   hiop->sp->options->SetStringValue("duals_init", "zero");
 
   hiop->sp->options->SetStringValue("fact_acceptor", "inertia_free");


### PR DESCRIPTION

**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [x] OPFLOW
- [x] SOPFLOW
- [x] SCOPFLOW
- [x] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

ExaGO was using incorrect HiOp option names, causing HiOp to ignore them and use different option values than those intended by ExaGO. This PR updates the names of these options.
