### PR TITLE
Don't use PetscFunctionReturn in ExaGOFinalize

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -217,7 +217,7 @@ extern "C" PetscErrorCode ExaGOInitialize(MPI_Comm, int *argc, char ***argv,
  * @note this takes care of Petsc finalization, so don't this function in
  * conjunction with `PetscFinalize`.
  */
-extern "C" PetscErrorCode ExaGOFinalize();
+extern "C" void ExaGOFinalize();
 
 /** Returns 1 if files exists, else 0 */
 bool DoesFileExist(const char *);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -174,6 +174,8 @@ static MPI_Comm ExaGOLogComm = MPI_COMM_SELF;
 PetscErrorCode ExaGOLogIsUsingLogFile(bool *flg) {
 #ifdef EXAGO_ENABLE_LOGGING
   *flg = ExaGOLogUseFile;
+#else
+  *flg = false;
 #endif
   return 0;
 }
@@ -581,8 +583,7 @@ PetscErrorCode ExaGOInitialize(MPI_Comm comm, int *argc, char ***argv,
   return 0;
 }
 
-PetscErrorCode ExaGOFinalize() {
-  PetscFunctionBegin;
+void ExaGOFinalize() {
   ExaGOLog(EXAGO_LOG_INFO, "Finalizing {} application.", ExaGOCurrentAppName);
   MPI_Comm comm = MPI_COMM_WORLD;
   int my_rank;
@@ -602,7 +603,6 @@ PetscErrorCode ExaGOFinalize() {
   if (!initialized) {
     MPI_Finalize();
   }
-  PetscFunctionReturn(0);
 }
 
 #undef EXAGO_LOG_ENSURE_INITIALIZED


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [X] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [X] Other

**This MR updates**
- [X] Header files
- [X] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

1. Changed `ExaGOFinalize` to a `void` function because you shouldn't use `PetscFunctionReturn` after the call to `PetscFinalize`.
2. Modified `ExaGOLogIsUsingLogFile` to provide `false` when logging is disabled (this avoids an uninitialized value).

Both of these issues were encountered while trying to discover a different memory issue.