### PR TITLE
Nicholson/petsc+metis

### DIFF
--- a/buildsystem/clang-hip/cache.cmake
+++ b/buildsystem/clang-hip/cache.cmake
@@ -19,9 +19,9 @@ set(EXAGO_BUILD_STATIC
     CACHE BOOL ""
 )
 
-message(STATUS "Building in debug mode")
+message(STATUS "Building in RelWithDebInfo mode")
 set(CMAKE_BUILD_TYPE
-    Debug
+    RelWithDebInfo
     CACHE STRING ""
 )
 

--- a/buildsystem/spack/frontier/modules/dependencies.sh
+++ b/buildsystem/spack/frontier/modules/dependencies.sh
@@ -117,7 +117,9 @@ module load umpire/6.0.0-rocmcc-6.3.1-3zjinbv
 module load hiop/1.1.0-rocmcc-6.3.1-iqwppvk
 # ipopt@=3.14.14%rocmcc@=6.3.1+coinhsl~debug~java~metis~mumps build_system=autotools arch=linux-sles15-zen3
 module load ipopt/3.14.14-rocmcc-6.3.1-djalso6
-# petsc@=3.22.1%rocmcc@=6.4.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind~metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.22.1-rocmcc-6.4.0-ipwxj6c
+# parmetis@=4.0.3%rocmcc@=6.3.1~gdb~int64~ipo+shared build_system=cmake build_type=Release generator=make patches=4f89253,50ed208,704b84f arch=linux-sles15-zen3
+module load parmetis/4.0.3-rocmcc-6.3.1-amlsqtx
+# petsc@=3.22.1%rocmcc@=6.4.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
+module load petsc/3.22.1-rocmcc-6.4.0-qlhkfd5
 # exago@=develop%rocmcc@=6.3.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make arch=linux-sles15-zen3
-## module load exago/develop-rocmcc-6.3.1-tylmjdf
+## module load exago/develop-rocmcc-6.3.1-kbxnjcf

--- a/buildsystem/spack/frontier/modules/dependencies.sh
+++ b/buildsystem/spack/frontier/modules/dependencies.sh
@@ -119,7 +119,7 @@ module load hiop/1.1.0-rocmcc-6.3.1-iqwppvk
 module load ipopt/3.14.14-rocmcc-6.3.1-djalso6
 # parmetis@=4.0.3%rocmcc@=6.3.1~gdb~int64~ipo+shared build_system=cmake build_type=Release generator=make patches=4f89253,50ed208,704b84f arch=linux-sles15-zen3
 module load parmetis/4.0.3-rocmcc-6.3.1-amlsqtx
-# petsc@=3.22.1%rocmcc@=6.4.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
-module load petsc/3.22.1-rocmcc-6.4.0-qlhkfd5
+# petsc@=3.22.1%rocmcc@=6.3.1~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib~hdf5~hpddm~hwloc~hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack~suite-sparse~superlu-dist~sycl~tetgen~trilinos~valgrind~zoltan build_system=generic clanguage=C memalign=none arch=linux-sles15-zen3
+module load petsc/3.22.1-rocmcc-6.3.1-krpsfil
 # exago@=develop%rocmcc@=6.3.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make arch=linux-sles15-zen3
-## module load exago/develop-rocmcc-6.3.1-kbxnjcf
+## module load exago/develop-rocmcc-6.3.1-rn7oc3p

--- a/buildsystem/spack/frontier/modules/exago.sh
+++ b/buildsystem/spack/frontier/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/stf006/world-shared/nkouk/exago-05-2025/spack-install/modules/linux-sles15-zen3
 # exago@=develop%rocmcc@=6.3.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make arch=linux-sles15-zen3
-module load exago/develop-rocmcc-6.3.1-tylmjdf
+module load exago/develop-rocmcc-6.3.1-kbxnjcf

--- a/buildsystem/spack/frontier/modules/exago.sh
+++ b/buildsystem/spack/frontier/modules/exago.sh
@@ -1,3 +1,3 @@
 module use -a /lustre/orion/stf006/world-shared/nkouk/exago-05-2025/spack-install/modules/linux-sles15-zen3
 # exago@=develop%rocmcc@=6.3.1~cuda+hiop~ipo+ipopt+logging+mpi~python+raja+rocm amdgpu_target=gfx90a build_system=cmake build_type=Release dev_path=/lustre/orion/scratch/nkouk/stf006/Codes/ExaGO generator=make arch=linux-sles15-zen3
-module load exago/develop-rocmcc-6.3.1-kbxnjcf
+module load exago/develop-rocmcc-6.3.1-rn7oc3p

--- a/buildsystem/spack/frontier/spack.yaml
+++ b/buildsystem/spack/frontier/spack.yaml
@@ -3,7 +3,7 @@ spack:
   - exago@develop%rocmcc@6.3.1 amdgpu_target=gfx90a
     ^coinhsl%gcc@14.2
     ^openblas%gcc@14.2
-    ^petsc%rocmcc@6.4.0 target=zen3
+    ^petsc%rocmcc@6.3.1 target=zen3
   view: false
   concretizer:
     unify: when_possible
@@ -16,19 +16,6 @@ spack:
         cxx: /opt/rocm-6.3.1/llvm/bin/amdclang++
         f77: /opt/rocm-6.3.1/llvm/bin/amdflang
         fc: /opt/rocm-6.3.1/llvm/bin/amdflang
-      flags: {}
-      operating_system: sles15
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
-  - compiler:
-      spec: rocmcc@6.4.0
-      paths:
-        cc: /opt/rocm-6.4.0/llvm/bin/amdclang
-        cxx: /opt/rocm-6.4.0/llvm/bin/amdclang++
-        f77: /opt/rocm-6.4.0/llvm/bin/amdflang
-        fc: /opt/rocm-6.4.0/llvm/bin/amdflang
       flags: {}
       operating_system: sles15
       target: x86_64
@@ -91,13 +78,13 @@ spack:
         - craype-accel-amd-gfx90a
         - craype-x86-trento
         - libfabric
-      - spec: cray-mpich@8.1.31 %rocmcc@6.4.0
+      - spec: cray-mpich@8.1.31 %rocmcc@6.3.1
         prefix: /opt/cray/pe/mpich/8.1.31/ofi/amd/6.0
         modules:
         - PrgEnv-amd
         - cray-mpich/8.1.31
-        - amd/6.4.0
-        - rocm/6.4.0
+        - amd/6.3.1
+        - rocm/6.3.1
         - craype-accel-amd-gfx90a
         - craype-x86-trento
         - libfabric

--- a/buildsystem/spack/frontier/spack.yaml
+++ b/buildsystem/spack/frontier/spack.yaml
@@ -77,7 +77,7 @@ spack:
     magma:
       require: '@2.8.0'
     petsc:
-      require: ~hypre~superlu-dist~hdf5~metis
+      require: ~hypre~superlu-dist~hdf5+metis
     cray-mpich:
       buildable: false
       externals:


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [x] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [x] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [x] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

This changes the `PETSc` build configuration on frontier to depend on `metis` (`parmetis` when `+mpi`).
- Changed the `rocmcc` version used to build `PETSc` to `6.3.1` to match what we are using to build other codes. 
- Changed the default build type from `Debug` to `RelWithDebInfo` for `clang-hip` (e.g., Frontier). Users building with the scripts more likely want an optimized build, and developers should know how to set their desired build type.

**Linked Issue(s)**

This does not fix existing issues (e.g., segfault when running with larger systems), but it does not hurt to merge it.