### PR TITLE
Fixes to CMake configuration to enable testing from build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,6 @@ endif()
 # Install data files
 install(FILES ${EXAGO_DATA_FILES} DESTINATION datafiles)
 
-
 # EXAGO headers to install
 set(EXAGO_COMMON_INCLUDE
     include/constants.h include/version.h ${PROJECT_BINARY_DIR}/exago_config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/buildsystem/cmake)
 include(ExaGOCheckGitSubmodules)
 
 # Set the path to options file in EXAGO installation
-set(EXAGO_OPTIONS_DIR ${CMAKE_INSTALL_PREFIX}/share/exago/options)
-set(EXAGO_DATAFILES_DIR ${CMAKE_INSTALL_PREFIX}/share/exago/datafiles)
+set(EXAGO_OPTIONS_DIR ${CMAKE_SOURCE_DIR}/options)
+set(EXAGO_DATAFILES_DIR ${CMAKE_SOURCE_DIR}/datafiles)
 
 # Specify whether to build shared libraries, static libraries, or both
 option(EXAGO_BUILD_SHARED "Build shared libraries" OFF)
@@ -370,30 +370,8 @@ if(EXAGO_ENABLE_IPOPT OR EXAGO_ENABLE_HIOP)
 endif()
 
 # Install data files
-install(FILES ${EXAGO_DATA_FILES} DESTINATION ${EXAGO_DATAFILES_DIR})
+install(FILES ${EXAGO_DATA_FILES} DESTINATION datafiles)
 
-if(EXAGO_ENABLE_IPOPT OR EXAGO_ENABLE_HIOP)
-  install(DIRECTORY datafiles/unit DESTINATION ${EXAGO_DATAFILES_DIR})
-  install(DIRECTORY datafiles/TAMU200_scenarios
-          DESTINATION ${EXAGO_DATAFILES_DIR}
-  )
-  install(DIRECTORY datafiles/test_validation
-          DESTINATION ${EXAGO_DATAFILES_DIR}
-  )
-endif()
-
-install(DIRECTORY datafiles/case9 DESTINATION ${EXAGO_DATAFILES_DIR})
-
-# Install data files in build directory for testing
-file(INSTALL ${EXAGO_DATA_FILES} DESTINATION datafiles)
-file(INSTALL datafiles/case9 DESTINATION datafiles)
-
-if(EXAGO_ENABLE_IPOPT OR EXAGO_ENABLE_HIOP)
-  file(INSTALL datafiles/TAMU200_scenarios DESTINATION datafiles)
-  file(INSTALL datafiles/unit DESTINATION datafiles)
-  # Custom testing data files
-  file(INSTALL datafiles/test_validation DESTINATION datafiles)
-endif()
 
 # EXAGO headers to install
 set(EXAGO_COMMON_INCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ if(EXAGO_ENABLE_IPOPT)
 endif()
 
 # Install options files
-install(FILES ${EXAGO_OPTIONS_FILES} DESTINATION ${EXAGO_OPTIONS_DIR})
+install(FILES ${EXAGO_OPTIONS_FILES} DESTINATION options)
 
 # EXAGO datafiles to install
 set(EXAGO_DATA_FILES ${PROJECT_SOURCE_DIR}/datafiles/case118.m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/buildsystem/cmake)
 include(ExaGOCheckGitSubmodules)
 
 # Set the path to options file in EXAGO installation
-set(EXAGO_OPTIONS_DIR "${CMAKE_INSTALL_PREFIX}/share/exago/options")
-set(EXAGO_DATAFILES_DIR "${CMAKE_INSTALL_PREFIX}/share/exago/datafiles")
+set(EXAGO_OPTIONS_DIR ${CMAKE_INSTALL_PREFIX}/share/exago/options)
+set(EXAGO_DATAFILES_DIR ${CMAKE_INSTALL_PREFIX}/share/exago/datafiles)
 
 # Specify whether to build shared libraries, static libraries, or both
 option(EXAGO_BUILD_SHARED "Build shared libraries" OFF)
@@ -62,20 +62,25 @@ option(EXAGO_ENABLE_IPOPT "Enable Ipopt support" ON)
 # HiOP support is disabled by default
 option(EXAGO_ENABLE_HIOP "Enable HiOP support" OFF)
 
-# GPU support is disabled by default
-option(EXAGO_ENABLE_GPU "Enable GPU support" OFF)
+#include(CMakeDependentOption)
 
-include(CMakeDependentOption)
-
-# CUDA is disabled by default, but is default when EXAGO_ENABLE_GPU=ON
-cmake_dependent_option(
-  EXAGO_ENABLE_CUDA "Build with support for CUDA" OFF "EXAGO_ENABLE_GPU" OFF
-)
+# CUDA is disabled by default
+option(EXAGO_ENABLE_CUDA "Build with support for CUDA" OFF)
 
 # HIP is disabled by default
-cmake_dependent_option(
-  EXAGO_ENABLE_HIP "Build with support for HIP" OFF "EXAGO_ENABLE_GPU" OFF
-)
+option(EXAGO_ENABLE_HIP "Build with support for HIP" OFF)
+
+# GPU support is enabled when either CUDA or HIP is enabled
+option(EXAGO_ENABLE_GPU "Enable GPU support" OFF)
+# Marked as advanced since it is toggled automatically
+mark_as_advanced(FORCE EXAGO_ENABLE_GPU)
+
+if(RESOLVE_ENABLE_CUDA OR RESOLVE_ENABLE_HIP)
+  set(RESOLVE_USE_GPU
+      ON
+      CACHE BOOL "Using GPU." FORCE
+  )
+endif()
 
 # Enable RAJA support
 option(EXAGO_ENABLE_RAJA "Enables RAJA and Umpire libraries" OFF)
@@ -223,6 +228,7 @@ endif(EXAGO_ENABLE_GPU)
 
 # Find PETSc and configure related variables
 if(EXAGO_ENABLE_PETSC)
+  set(PETSC_DIR CACHE PATH "Path to PETSc installation root directory")
   include(FindPkgConfig)
   # Include petsc package path in pkg_config_path
   set(PKG_CONFIG_PATH_save $ENV{PKG_CONFIG_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,12 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   )
   set(CMAKE_BUILD_TYPE
       "${_DEFAULT_CMAKE_BUILD_TYPE}"
-      CACHE STRING "Choose the type of build." FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "None" "Debug" "Release"
-                                               "MinSizeRel" "RelWithDebInfo")
+      CACHE STRING "Choose the type of build." FORCE
+  )
+  set_property(
+    CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "None" "Debug" "Release"
+                                    "MinSizeRel" "RelWithDebInfo"
+  )
 else()
   message(STATUS "Building SUNDIALS in '${CMAKE_BUILD_TYPE}' mode.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,56 +185,35 @@ else()
   set(TESTING_MAX_NUMPROCS 1)
 endif(EXAGO_ENABLE_MPI)
 
-# If GPU support is enabled, find CUDA
-if(EXAGO_ENABLE_GPU)
+# If CUDA support is enabled, set up CUDA compiler and flags
+if(EXAGO_ENABLE_CUDA)
+  include(CheckLanguage)
+  enable_language(CUDA)
+  check_language(CUDA)
 
-  if(NOT EXAGO_ENABLE_CUDA AND NOT EXAGO_ENABLE_HIP)
-    message(
-      WARNING
-        "\nGPU is enabled, but both CUDA and HIP are disabled. "
-        "Enabling CUDA by default. If you would like to enable a particular GPU "
-        "platform, set one of the following variables to ON: "
-        "\n* EXAGO_ENABLE_CUDA"
-        "\n* EXAGO_ENABLE_HIP"
-    )
-    set(EXAGO_ENABLE_CUDA
-        ON
-        CACHE BOOL ""
-    )
+  find_package(CUDA REQUIRED)
+
+  if(NOT DEFINED CMAKE_CUDA_STANDARD)
+    set(CMAKE_CUDA_STANDARD 11)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   endif()
 
-  if(EXAGO_ENABLE_CUDA)
-    include(CheckLanguage)
-    enable_language(CUDA)
-    check_language(CUDA)
-
-    find_package(CUDA REQUIRED)
-
-    if(NOT DEFINED CMAKE_CUDA_STANDARD)
-      set(CMAKE_CUDA_STANDARD 11)
-      set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-    endif()
-
-    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-      set(CMAKE_CUDA_ARCHITECTURES 35)
-    endif()
-
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
-
-    # HiOp requires this since we require static
-    set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
-
-  elseif(EXAGO_ENABLE_HIP)
-    set(EXAGO_HAVE_HIP 1)
-    add_definitions(-DHAVE_HIP) # For hipmagma
-    find_package(hip REQUIRED)
-  else()
-    message(
-      FATAL_ERROR "EXAGO_ENABLE_GPU enabled, but neither EXAGO_ENABLE_CUDA "
-                  "nor EXAGO_ENABLE_HIP is enabled!"
-    )
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 35)
   endif()
-endif(EXAGO_ENABLE_GPU)
+
+  set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
+
+  # HiOp requires this since we require static
+  set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
+endif(EXAGO_ENABLE_CUDA)
+
+# If HIP support is enabled, set up HIP compiler and flags
+if(EXAGO_ENABLE_HIP)
+  set(EXAGO_HAVE_HIP 1)
+  add_definitions(-DHAVE_HIP) # For hipmagma
+  find_package(hip REQUIRED)
+endif()
 
 # Find PETSc and configure related variables
 if(EXAGO_ENABLE_PETSC)
@@ -351,8 +330,6 @@ endif()
 
 # Install options files
 install(FILES ${EXAGO_OPTIONS_FILES} DESTINATION ${EXAGO_OPTIONS_DIR})
-# Install options file to binary dir for testing
-file(INSTALL ${EXAGO_OPTIONS_FILES} DESTINATION options)
 
 # EXAGO datafiles to install
 set(EXAGO_DATA_FILES ${PROJECT_SOURCE_DIR}/datafiles/case118.m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                                     "MinSizeRel" "RelWithDebInfo"
   )
 else()
-  message(STATUS "Building SUNDIALS in '${CMAKE_BUILD_TYPE}' mode.")
+  message(STATUS "Building ExaGO in '${CMAKE_BUILD_TYPE}' mode.")
 endif()
 
 # Make CMake debugging available globally

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ option(EXAGO_ENABLE_GPU "Enable GPU support" OFF)
 # Marked as advanced since it is toggled automatically
 mark_as_advanced(FORCE EXAGO_ENABLE_GPU)
 
-if(RESOLVE_ENABLE_CUDA OR RESOLVE_ENABLE_HIP)
-  set(RESOLVE_USE_GPU
+if(EXAGO_ENABLE_HIP OR EXAGO_ENABLE_CUDA)
+  set(EXAGO_ENABLE_GPU
       ON
       CACHE BOOL "Using GPU." FORCE
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,20 @@ if(POLICY CMP0104)
   cmake_policy(SET CMP0104 NEW) # CMake 3.18
 endif()
 
-if("${CMAKE_BUILD_TYPE}" STREQUAL "")
-  set(CMAKE_BUILD_TYPE
-      "Release"
-      CACHE STRING ""
+# We default to release builds
+set(_DEFAULT_CMAKE_BUILD_TYPE RelWithDebInfo)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(
+    STATUS
+      "Building ExaGO in '${_DEFAULT_CMAKE_BUILD_TYPE}' mode as CMAKE_BUILD_TYPE was not specified."
   )
+  set(CMAKE_BUILD_TYPE
+      "${_DEFAULT_CMAKE_BUILD_TYPE}"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "None" "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
+else()
+  message(STATUS "Building SUNDIALS in '${CMAKE_BUILD_TYPE}' mode.")
 endif()
 
 # Make CMake debugging available globally
@@ -61,8 +70,6 @@ option(EXAGO_ENABLE_IPOPT "Enable Ipopt support" ON)
 
 # HiOP support is disabled by default
 option(EXAGO_ENABLE_HIOP "Enable HiOP support" OFF)
-
-#include(CMakeDependentOption)
 
 # CUDA is disabled by default
 option(EXAGO_ENABLE_CUDA "Build with support for CUDA" OFF)
@@ -265,8 +272,8 @@ if(EXAGO_ENABLE_HIOP)
     # defined in HiOp 0.7.0+ if hiop+raja RAJA part of ExaGO will not work if
     # HiOp is not built with RAJA
     message(
-      STATUS
-        "Warning: HiOp was built without RAJA - ExaGO RAJA module calling HiOp may not work!"
+      WARNING
+        "HiOp was built without RAJA - ExaGO RAJA module calling HiOp may not work!"
     )
   endif()
 endif(EXAGO_ENABLE_HIOP)

--- a/include/exago_build_options.h.in
+++ b/include/exago_build_options.h.in
@@ -1,5 +1,5 @@
-#ifndef _EXAGO_CONFIG_H_
-#define _EXAGO_CONFIG_H_
+#ifndef _EXAGO_BUILD_OPTIONS_H_
+#define _EXAGO_BUILD_OPTIONS_H_
 
 /**
  * \brief Define some macros for configure-time variables to make help messages
@@ -43,4 +43,4 @@
 #define EXAGO_IPOPT_INCLUDES "@IPOPT_INCLUDES@"
 #endif
 
-#endif /* _EXAGO_CONFIG_H_ */
+#endif /* _EXAGO_BUILD_OPTIONS_H_ */

--- a/tests/CTestCustom.cmake.in
+++ b/tests/CTestCustom.cmake.in
@@ -1,2 +1,2 @@
-set(CTEST_CUSTOM_PRE_TEST "perl @CMAKE_SOURCE_DIR@/tests/functionality/scripts/pre_test.pl @CMAKE_BINARY_DIR@/tests/functionality")
-set(CTEST_CUSTOM_POST_TEST "perl @CMAKE_SOURCE_DIR@/tests/functionality/scripts/post_test.pl @CMAKE_BINARY_DIR@/tests/functionality")
+  set(CTEST_CUSTOM_PRE_TEST "perl @CMAKE_SOURCE_DIR@/tests/functionality/scripts/pre_test.pl @CMAKE_BINARY_DIR@/tests/functionality")
+  set(CTEST_CUSTOM_POST_TEST "perl @CMAKE_SOURCE_DIR@/tests/functionality/scripts/post_test.pl @CMAKE_BINARY_DIR@/tests/functionality")

--- a/tests/functionality/opflow/CMakeLists.txt
+++ b/tests/functionality/opflow/CMakeLists.txt
@@ -80,6 +80,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_opflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/ipopt_pbpol.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
     DEPENDS
     IPOPT
   )

--- a/tests/functionality/opflow/CMakeLists.txt
+++ b/tests/functionality/opflow/CMakeLists.txt
@@ -45,18 +45,21 @@ if(EXAGO_INSTALL_TESTS)
     HIOP_SPARSE
   )
 
-  exago_add_test(
-    NAME
-    FUNCTIONALITY_TEST_OPFLOW_RAJAHIOP_SPARSE_GPU_TOML_TESTSUITE
-    COMMAND
-    ${RUNCMD}
-    $<TARGET_FILE:test_opflow_functionality>
-    ${CMAKE_CURRENT_SOURCE_DIR}/hiop_pbpolrajahiopsparse_gpu.toml
-    DEPENDS
-    HIOP_SPARSE
-    RAJA
-    GPU
-  )
+  if(EXAGO_ENABLE_GPU)
+    exago_add_test(
+      NAME
+      FUNCTIONALITY_TEST_OPFLOW_RAJAHIOP_SPARSE_GPU_TOML_TESTSUITE
+      COMMAND
+      ${RUNCMD}
+      $<TARGET_FILE:test_opflow_functionality>
+      ${CMAKE_CURRENT_SOURCE_DIR}/hiop_pbpolrajahiopsparse_gpu.toml
+      DEPENDS
+      HIOP_SPARSE
+      RAJA
+      WORKING_DIRECTORY
+      ${CMAKE_SOURCE_DIR}
+    )
+  endif(EXAGO_ENABLE_GPU)
 
   # Note: All cartesian and/or current balance models are way behind. These
   # models should not be used and their tests should be disabled.
@@ -124,6 +127,8 @@ if(EXAGO_INSTALL_TESTS)
     -opflow_allow_lineflow_violation
     -opflow_lineflowviolation_penalty
     100
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
     DEPENDS
     IPOPT
     HIOP

--- a/tests/functionality/pflow/CMakeLists.txt
+++ b/tests/functionality/pflow/CMakeLists.txt
@@ -26,6 +26,8 @@ if(EXAGO_INSTALL_TESTS)
       ${EXAGO_EXTRA_MPI_FLAGS}
       $<TARGET_FILE:test_pflow_functionality>
       ${CMAKE_CURRENT_SOURCE_DIR}/pflow${np}procs.toml
+      WORKING_DIRECTORY
+      ${CMAKE_SOURCE_DIR}
     )
   endforeach(np)
 

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -107,6 +107,8 @@ if(EXAGO_INSTALL_TESTS)
     ${TESTING_MAX_NUMPROCS}
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_cont_mpi.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -135,6 +137,8 @@ if(EXAGO_INSTALL_TESTS)
     ${TESTING_MAX_NUMPROCS}
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/hiop_raja.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   foreach(fmt "MATPOWER" "CSV" "JSON" "MINIMAL")

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -23,6 +23,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/ipopt_cont.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -34,6 +36,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_scopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/empar_cont.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   # Disabled test for now, feature not ready yet

--- a/tests/functionality/sopflow/CMakeLists.txt
+++ b/tests/functionality/sopflow/CMakeLists.txt
@@ -27,6 +27,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_sopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/sopflow_multiscenario.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -38,6 +40,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_sopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/sopflow_multiscenario2.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -53,6 +57,8 @@ if(EXAGO_INSTALL_TESTS)
     -opflow_ignore_lineflow_constraints
     -hiop_mem_space
     HOST
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -78,6 +84,8 @@ if(EXAGO_INSTALL_TESTS)
     ${RUNCMD}
     $<TARGET_FILE:test_sopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/sopflow_multicontingency.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -92,6 +100,8 @@ if(EXAGO_INSTALL_TESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/sopflow_multiscenario_serial.toml
     -hiop_mem_space
     HOST
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(
@@ -106,6 +116,8 @@ if(EXAGO_INSTALL_TESTS)
     ${TESTING_MAX_NUMPROCS}
     $<TARGET_FILE:test_sopflow_functionality>
     ${CMAKE_CURRENT_SOURCE_DIR}/sopflow_multiscenario_parallel.toml
+    WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}
   )
 
   exago_add_test(

--- a/tests/unit/opflow/objective/CMakeLists.txt
+++ b/tests/unit/opflow/objective/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(objective_acopf PRIVATE ../../utils)
 target_include_directories(objective_acopf PRIVATE ../)
 
 # Network files to run on - doing 3 and 600 bus examples.
-set(prefix ${EXAGO_DATAFILES_DIR}/unit/opflow/objective/)
+set(prefix ${CMAKE_SOURCE_DIR}/datafiles/unit/opflow/objective/)
 set(obj_network_files OF_unittestx3.m OF_unittestx600.m)
 # Map num_copies to a specific netfile
 set(num_copies 3 600)


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [ ] Documentation
- [x] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [x] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [x] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

I made some changes to CMake, mainly to enable running tests without installing ExaGO first. This is still work in progress but some feedback would be helpful to figure out how to proceed.

Closes #148.
Closes #58.
