### PR TITLE
Do not create SOPFLOW vectors and matrices when solver is HIOP.

### DIFF
--- a/include/private/sopflowimpl.h
+++ b/include/private/sopflowimpl.h
@@ -215,6 +215,9 @@ struct _p_SOPFLOW {
   char ctgcfile[PETSC_MAX_PATH_LEN]; /* Contingency file */
   ContingencyFileInputFormat ctgcfileformat;
 
+  PetscBool issolver_ipopt;
+  PetscBool issolver_hiop;
+
   // Only used for HIOP solver
   std::string subproblem_model;
   std::string subproblem_solver;

--- a/src/sopflow/interface/sopflow.cpp
+++ b/src/sopflow/interface/sopflow.cpp
@@ -109,31 +109,31 @@ PetscErrorCode SOPFLOWDestroy(SOPFLOW *sopflow) {
 
   PetscFunctionBegin;
 
-  /* Solution vector */
-  ierr = VecDestroy(&(*sopflow)->X);
-  CHKERRQ(ierr);
-  ierr = VecDestroy(&(*sopflow)->gradobj);
-  CHKERRQ(ierr);
+  if((*sopflow)->issolver_ipopt) {
+    /* Solution vector */
+    ierr = VecDestroy(&(*sopflow)->X);
+    CHKERRQ(ierr);
+    ierr = VecDestroy(&(*sopflow)->gradobj);
+    CHKERRQ(ierr);
 
-  /* Lower and upper bounds on X */
-  ierr = VecDestroy(&(*sopflow)->Xl);
-  CHKERRQ(ierr);
-  ierr = VecDestroy(&(*sopflow)->Xu);
-  CHKERRQ(ierr);
+    /* Lower and upper bounds on X */
+    ierr = VecDestroy(&(*sopflow)->Xl);
+    CHKERRQ(ierr);
+    ierr = VecDestroy(&(*sopflow)->Xu);
+    CHKERRQ(ierr);
 
-  /* Constraints vector */
-  ierr = VecDestroy(&(*sopflow)->G);
-  CHKERRQ(ierr);
+    /* Constraints vector */
+    ierr = VecDestroy(&(*sopflow)->G);
+    CHKERRQ(ierr);
 
-  ierr = VecDestroy(&(*sopflow)->Gl);
-  CHKERRQ(ierr);
-  ierr = VecDestroy(&(*sopflow)->Gu);
-  CHKERRQ(ierr);
-  ierr = VecDestroy(&(*sopflow)->Lambda);
-  CHKERRQ(ierr);
+    ierr = VecDestroy(&(*sopflow)->Gl);
+    CHKERRQ(ierr);
+    ierr = VecDestroy(&(*sopflow)->Gu);
+    CHKERRQ(ierr);
+    ierr = VecDestroy(&(*sopflow)->Lambda);
+    CHKERRQ(ierr);
 
-  /* Jacobian of constraints and Hessian */
-  if ((*sopflow)->comm->size == 1) {
+    /* Jacobian of constraints and Hessian */
     ierr = MatDestroy(&(*sopflow)->Jac);
     CHKERRQ(ierr);
     ierr = MatDestroy(&(*sopflow)->Hes);
@@ -578,7 +578,6 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
   char windgen[PETSC_MAX_PATH_LEN];
   PetscBool flgctgc = PETSC_FALSE;
   PetscBool flgwindgen = PETSC_FALSE;
-  PetscBool issopflowsolverhiop;
   PetscBool flg;
 
   char opflowmodelname[max_model_name_len];
@@ -891,7 +890,9 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     }
   }
 
-  ierr = PetscStrcmp(sopflow->solvername, "HIOP", &issopflowsolverhiop);
+  ierr = PetscStrcmp(sopflow->solvername, "HIOP", &sopflow->issolver_hiop);
+  CHKERRQ(ierr);
+  ierr = PetscStrcmp(sopflow->solvername, "IPOPT", &sopflow->issolver_ipopt);
   CHKERRQ(ierr);
 
   if (!sopflow->ismulticontingency) {
@@ -981,7 +982,7 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
       }
 
       /* Set subproblem parameters and partial setup */
-      if (issopflowsolverhiop) {
+      if (sopflow->issolver_hiop) {
         ierr = OPFLOWSetModel(sopflow->opflows[s], sopflow->subproblem_model);
         CHKERRQ(ierr);
         ierr = OPFLOWSetSolver(sopflow->opflows[s], sopflow->subproblem_solver);
@@ -1153,40 +1154,40 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     }
   }
 
-  /* Create vector X */
-  ierr = VecCreate(sopflow->comm->type, &sopflow->X);
-  CHKERRQ(ierr);
-  ierr = VecSetSizes(sopflow->X, sopflow->nx, PETSC_DECIDE);
-  CHKERRQ(ierr);
-  ierr = VecSetFromOptions(sopflow->X);
-  CHKERRQ(ierr);
-  ierr = VecGetSize(sopflow->X, &sopflow->Nx);
-  CHKERRQ(ierr);
-
-  ierr = VecDuplicate(sopflow->X, &sopflow->Xl);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(sopflow->X, &sopflow->Xu);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(sopflow->X, &sopflow->gradobj);
-  CHKERRQ(ierr);
-
-  /* vector for constraints */
-  ierr = VecCreate(sopflow->comm->type, &sopflow->G);
-  CHKERRQ(ierr);
-  ierr = VecSetSizes(sopflow->G, sopflow->ncon, PETSC_DECIDE);
-  CHKERRQ(ierr);
-  ierr = VecSetFromOptions(sopflow->G);
-  CHKERRQ(ierr);
-  ierr = VecGetSize(sopflow->G, &sopflow->Ncon);
-  CHKERRQ(ierr);
-
-  /* Constraint bounds vectors  */
-  ierr = VecDuplicate(sopflow->G, &sopflow->Gl);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(sopflow->G, &sopflow->Gu);
-  CHKERRQ(ierr);
-
-  if (sopflow->comm->size == 1) {
+  if(sopflow->issolver_ipopt) {
+    /* Create vector X */
+    ierr = VecCreate(sopflow->comm->type, &sopflow->X);
+    CHKERRQ(ierr);
+    ierr = VecSetSizes(sopflow->X, sopflow->nx, PETSC_DECIDE);
+    CHKERRQ(ierr);
+    ierr = VecSetFromOptions(sopflow->X);
+    CHKERRQ(ierr);
+    ierr = VecGetSize(sopflow->X, &sopflow->Nx);
+    CHKERRQ(ierr);
+    
+    ierr = VecDuplicate(sopflow->X, &sopflow->Xl);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(sopflow->X, &sopflow->Xu);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(sopflow->X, &sopflow->gradobj);
+    CHKERRQ(ierr);
+    
+    /* vector for constraints */
+    ierr = VecCreate(sopflow->comm->type, &sopflow->G);
+    CHKERRQ(ierr);
+    ierr = VecSetSizes(sopflow->G, sopflow->ncon, PETSC_DECIDE);
+    CHKERRQ(ierr);
+    ierr = VecSetFromOptions(sopflow->G);
+    CHKERRQ(ierr);
+    ierr = VecGetSize(sopflow->G, &sopflow->Ncon);
+    CHKERRQ(ierr);
+    
+    /* Constraint bounds vectors  */
+    ierr = VecDuplicate(sopflow->G, &sopflow->Gl);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(sopflow->G, &sopflow->Gu);
+    CHKERRQ(ierr);
+    
     /* Constraint Jacobian */
     ierr = MatCreate(sopflow->comm->type, &sopflow->Jac);
     CHKERRQ(ierr);
@@ -1202,9 +1203,9 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
                                      (PetscInt)(0.1 * sopflow->Nx), NULL);
     CHKERRQ(ierr);
     ierr =
-        MatSetOption(sopflow->Jac, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+      MatSetOption(sopflow->Jac, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
     CHKERRQ(ierr);
-
+    
     /* Hessian */
     ierr = MatCreate(sopflow->comm->type, &sopflow->Hes);
     CHKERRQ(ierr);
@@ -1223,11 +1224,11 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     ierr =
         MatSetOption(sopflow->Hes, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
     CHKERRQ(ierr);
-  }
 
-  /* Lagrangian multipliers */
-  ierr = VecDuplicate(sopflow->G, &sopflow->Lambda);
-  CHKERRQ(ierr);
+    /* Lagrangian multipliers */
+    ierr = VecDuplicate(sopflow->G, &sopflow->Lambda);
+    CHKERRQ(ierr);
+  }
 
   ierr = (*sopflow->solverops.setup)(sopflow);
   CHKERRQ(ierr);
@@ -1245,7 +1246,6 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
 */
 PetscErrorCode SOPFLOWSolve(SOPFLOW sopflow) {
   PetscErrorCode ierr;
-  PetscBool issolver_ipopt;
 
   PetscFunctionBegin;
 
@@ -1253,10 +1253,7 @@ PetscErrorCode SOPFLOWSolve(SOPFLOW sopflow) {
     ierr = SOPFLOWSetUp(sopflow);
   }
 
-  ierr = PetscStrcmp(sopflow->solvername, "IPOPT", &issolver_ipopt);
-  CHKERRQ(ierr);
-
-  if (issolver_ipopt) {
+  if (sopflow->issolver_ipopt) {
     /* Set bounds on variables */
     if (sopflow->modelops.setvariablebounds) {
       ierr = (*sopflow->modelops.setvariablebounds)(sopflow, sopflow->Xl,

--- a/src/sopflow/interface/sopflow.cpp
+++ b/src/sopflow/interface/sopflow.cpp
@@ -109,7 +109,7 @@ PetscErrorCode SOPFLOWDestroy(SOPFLOW *sopflow) {
 
   PetscFunctionBegin;
 
-  if((*sopflow)->issolver_ipopt) {
+  if ((*sopflow)->issolver_ipopt) {
     /* Solution vector */
     ierr = VecDestroy(&(*sopflow)->X);
     CHKERRQ(ierr);
@@ -1154,7 +1154,7 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     }
   }
 
-  if(sopflow->issolver_ipopt) {
+  if (sopflow->issolver_ipopt) {
     /* Create vector X */
     ierr = VecCreate(sopflow->comm->type, &sopflow->X);
     CHKERRQ(ierr);
@@ -1164,14 +1164,14 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     CHKERRQ(ierr);
     ierr = VecGetSize(sopflow->X, &sopflow->Nx);
     CHKERRQ(ierr);
-    
+
     ierr = VecDuplicate(sopflow->X, &sopflow->Xl);
     CHKERRQ(ierr);
     ierr = VecDuplicate(sopflow->X, &sopflow->Xu);
     CHKERRQ(ierr);
     ierr = VecDuplicate(sopflow->X, &sopflow->gradobj);
     CHKERRQ(ierr);
-    
+
     /* vector for constraints */
     ierr = VecCreate(sopflow->comm->type, &sopflow->G);
     CHKERRQ(ierr);
@@ -1181,13 +1181,13 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
     CHKERRQ(ierr);
     ierr = VecGetSize(sopflow->G, &sopflow->Ncon);
     CHKERRQ(ierr);
-    
+
     /* Constraint bounds vectors  */
     ierr = VecDuplicate(sopflow->G, &sopflow->Gl);
     CHKERRQ(ierr);
     ierr = VecDuplicate(sopflow->G, &sopflow->Gu);
     CHKERRQ(ierr);
-    
+
     /* Constraint Jacobian */
     ierr = MatCreate(sopflow->comm->type, &sopflow->Jac);
     CHKERRQ(ierr);
@@ -1203,9 +1203,9 @@ PetscErrorCode SOPFLOWSetUp(SOPFLOW sopflow) {
                                      (PetscInt)(0.1 * sopflow->Nx), NULL);
     CHKERRQ(ierr);
     ierr =
-      MatSetOption(sopflow->Jac, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+        MatSetOption(sopflow->Jac, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
     CHKERRQ(ierr);
-    
+
     /* Hessian */
     ierr = MatCreate(sopflow->comm->type, &sopflow->Hes);
     CHKERRQ(ierr);


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [x] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [x] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

cherry-pick of https://github.com/pnnl/ExaGO/commit/a292b9e682d9bdad463d44a0f446da654408f9b7
This is the fix @abhyshr used to run large numbers of contingencies with HiOp PriDec for the KPP2. I have successfully used this in last year's scaling runs. It will be helpful to have it in the `develop` branch.

**Linked Issue(s)**

Closes #159