### PR TITLE
Docs/fork pr workflow

### DIFF
--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -93,7 +93,7 @@ $ git push --force-with-lease origin develop
 If working with a fork, after pushing your feature branch to `origin`, create a Pull Request on GitHub:
 1. Navigate to the original ExaGO repository at https://github.com/pnnl/ExaGO
 2. GitHub will typically show a banner to create a PR from your recently pushed branch
-3. Create a PR from `yourusername:my-cool-feature` → `pnnl:develop`
+3. Create a PR from `yourusername:my-cool-feature` → `pnnl:my-cool-feature`
 
 This will ensure you are rebased on the most recent development branch. If you see [open pull requests on ExaGO's repository](https://github.com/pnnl/ExaGO/pulls) that touch the same lines of code that you are working on, please coordinate with the developers of that merge request so your work doesn't conflict.
 

--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -11,12 +11,33 @@
 
 ### Development Workflow
 
-#### Setting Up the Upstream Remote
+#### Getting Started: Fork and Clone
 
-Before contributing to ExaGO, configure the `upstream` remote to point to the original repository:
+**If you don't have direct write access to the ExaGO repository:**
+
+1. Fork the repository on GitHub:
+   - Navigate to https://github.com/pnnl/ExaGO
+   - Click the "Fork" button in the top right
+   - This creates your fork at `https://github.com/yourusername/ExaGO`
+
+2. Clone your fork:
+   ```bash
+   $ git clone https://github.com/yourusername/ExaGO.git
+   $ cd ExaGO
+   ```
+
+**If you have direct write access:**
 
 ```bash
-$ cd exago
+$ git clone https://github.com/pnnl/ExaGO.git
+$ cd ExaGO
+```
+
+#### Setting Up the Upstream Remote
+
+After cloning, configure the `upstream` remote to point to the original repository:
+
+```bash
 $ git remote add upstream https://github.com/pnnl/ExaGO.git
 $ git fetch upstream
 ```
@@ -52,7 +73,7 @@ To submit a merge request, please make sure your branch is up to date with the o
 ```bash
 $ git checkout my-cool-feature
 $ git pull --rebase upstream develop
-$ git push --force-with-lease
+$ git push --force-with-lease origin my-cool-feature
 ```
 
 **If working with a fork, also keep your fork's `develop` branch synchronized:**
@@ -60,8 +81,19 @@ $ git push --force-with-lease
 ```bash
 $ git checkout develop
 $ git pull --rebase upstream develop
-$ git push --force-with-lease
+$ git push --force-with-lease origin develop
 ```
+
+**Note on remotes:**
+- `upstream` refers to the original ExaGO repository (`https://github.com/pnnl/ExaGO.git`) - you **pull** from here to stay up to date
+- `origin` refers to your fork (if you forked) or the original repository (if you have direct access) - you **push** to here
+
+**Submitting a Pull Request:**
+
+If working with a fork, after pushing your feature branch to `origin`, create a Pull Request on GitHub:
+1. Navigate to the original ExaGO repository at https://github.com/pnnl/ExaGO
+2. GitHub will typically show a banner to create a PR from your recently pushed branch
+3. Create a PR from `yourusername:my-cool-feature` → `pnnl:develop`
 
 This will ensure you are rebased on the most recent development branch. If you see [open pull requests on ExaGO's repository](https://github.com/pnnl/ExaGO/pulls) that touch the same lines of code that you are working on, please coordinate with the developers of that merge request so your work doesn't conflict.
 

--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -93,7 +93,8 @@ $ git push --force-with-lease origin develop
 If working with a fork, after pushing your feature branch to `origin`, create a Pull Request on GitHub:
 1. Navigate to the original ExaGO repository at https://github.com/pnnl/ExaGO
 2. GitHub will typically show a banner to create a PR from your recently pushed branch
-3. Create a PR from `yourusername:my-cool-feature` → `pnnl:my-cool-feature`
+3. **Ensure a corresponding feature branch exists on upstream**: Coordinate with maintainers to confirm that a feature branch (e.g., `my-cool-feature`) has been created on the upstream repository. This allows CI tests to run on the upstream feature branch before merging to `develop`
+4. Create a PR from `yourusername:my-cool-feature` → `pnnl:my-cool-feature`
 
 This will ensure you are rebased on the most recent development branch. If you see [open pull requests on ExaGO's repository](https://github.com/pnnl/ExaGO/pulls) that touch the same lines of code that you are working on, please coordinate with the developers of that merge request so your work doesn't conflict.
 

--- a/docs/developer_guidelines.md
+++ b/docs/developer_guidelines.md
@@ -11,28 +11,59 @@
 
 ### Development Workflow
 
+#### Setting Up the Upstream Remote
+
+Before contributing to ExaGO, configure the `upstream` remote to point to the original repository:
+
+```bash
+$ cd exago
+$ git remote add upstream https://github.com/pnnl/ExaGO.git
+$ git fetch upstream
+```
+
+To verify your remotes are set up correctly:
+
+```bash
+$ git remote -v
+```
+
+You should see:
+- `upstream` pointing to `https://github.com/pnnl/ExaGO.git` (the original repository)
+- `origin` pointing to your fork (if you forked) or the original repository (if you have direct access)
+
 #### P022: Branch Off Of `develop` Unless You Have a Good Reason Not To
 
 To get started contributing to ExaGO, check out a feature or fix branch off of
 the `develop` branch:
 
-```shell
+```bash
 $ cd exago
 $ git checkout develop
-$ git checkout -b my-cool-feature-dev
+$ git pull --rebase upstream develop
+$ git checkout -b my-cool-feature
 ```
 
 #### P023: Keep MRs Up To Date With Target Branch
 
-To submit a merge request, please make sure your branch is up to date with
-current development like so:
+To submit a merge request, please make sure your branch is up to date with the original repository's `develop` branch. Use `upstream` to refer to the original ExaGO repository (whether you have direct access or are working with a fork).
 
-```shell
-$ git pull --rebase origin develop
+**Keep your feature branch updated:**
+
+```bash
+$ git checkout my-cool-feature
+$ git pull --rebase upstream develop
+$ git push --force-with-lease
 ```
 
-This will ensure you are rebased on the most recent development branch.
-If you see [open pull requests on ExaGO's repository](https://github.com/pnnl/ExaGO/pulls) that touch the same lines of code that you are working on, please coordinate with the developers of that merge request so your work doesn't conflict.
+**If working with a fork, also keep your fork's `develop` branch synchronized:**
+
+```bash
+$ git checkout develop
+$ git pull --rebase upstream develop
+$ git push --force-with-lease
+```
+
+This will ensure you are rebased on the most recent development branch. If you see [open pull requests on ExaGO's repository](https://github.com/pnnl/ExaGO/pulls) that touch the same lines of code that you are working on, please coordinate with the developers of that merge request so your work doesn't conflict.
 
 #### P001: Don't Run Continuous Integration Pipelines If You Only Changed Documentation
 


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [ ] Resolves bug
- [x] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [ ] SCOPFLOW
- [ ] TCOPFLOW
- [ ] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [x] Web docs
- [ ] Other

**This MR updates**
- [ ] Header files
- [ ] Source code
- [ ] CMake build system
- [ ] Spack configuration
- [x] Web docs
- [ ] Manual
- [ ] Other

## Summary
Improve developer documentation for fork-based contribution workflow. Previously assumed users had a local clone and direct access to the ExaGO repo.

## Changes
- **Added fork and clone instructions**: Step-by-step guide for forking on GitHub and cloning your fork vs. cloning with direct access
- **Clarified remote conventions**: Consistently use `upstream` (original repo, pull from) and `origin` (your fork, push to). Added explicit `origin` in push commands for clarity.
- **Updated P022 and P023**: Added upstream sync before creating branches and made push destinations explicit in examples. Included PR submission workflow from fork to upstream.

## Impact
Makes the contribution process clearer for external contributors using forks while remaining compatible for developers with direct access.