### PR TITLE
Fixes to scopflow to run larger number of contigencies

### DIFF
--- a/include/opflow.h
+++ b/include/opflow.h
@@ -65,6 +65,7 @@ namespace OPFLOWOptions {
 const auto model = ExaGOStringOption("-opflow_model", "OPFLOW model name",
                                      "POWER_BALANCE_POLAR",
                                      {
+                                        "DCOPF",
 #ifdef EXAGO_ENABLE_HIOP
                                          "POWER_BALANCE_HIOP",
                                          "PBPOLRAJAHIOP",

--- a/include/opflow.h
+++ b/include/opflow.h
@@ -65,7 +65,7 @@ namespace OPFLOWOptions {
 const auto model = ExaGOStringOption("-opflow_model", "OPFLOW model name",
                                      "POWER_BALANCE_POLAR",
                                      {
-                                        "DCOPF",
+                                         "DCOPF",
 #ifdef EXAGO_ENABLE_HIOP
                                          "POWER_BALANCE_HIOP",
                                          "PBPOLRAJAHIOP",

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -801,7 +801,7 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
       if (scopflow->cstart + c == 0) { /* First stage */
         ierr = OPFLOWSetModel(scopflow->opflows[c], scopflow->subproblem_model);
         CHKERRQ(ierr);
-        ierr = OPFLOWSetSolver(scopflow->opflows[c], OPFLOWSOLVER_IPOPT);
+        ierr = OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
         CHKERRQ(ierr);
         ierr = OPFLOWSetObjectiveType(scopflow->opflows[c], MIN_GEN_COST);
         CHKERRQ(ierr);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -489,6 +489,7 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
   PetscInt c, i, j;
   PS ps;
   OPFLOW opflow;
+  PetscBool issolver_ipopt;
 
   char ploadprofile[PETSC_MAX_PATH_LEN];
   char qloadprofile[PETSC_MAX_PATH_LEN];
@@ -935,40 +936,49 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
     }
   }
 
-  /* Create vector X */
-  ierr = VecCreate(scopflow->comm->type, &scopflow->X);
+  ierr = PetscStrcmp(scopflow->solvername.c_str(), "IPOPT", &issolver_ipopt);
   CHKERRQ(ierr);
-  ierr = VecSetSizes(scopflow->X, scopflow->nx, PETSC_DECIDE);
-  CHKERRQ(ierr);
-  ierr = VecSetFromOptions(scopflow->X);
-  CHKERRQ(ierr);
-  ierr = VecGetSize(scopflow->X, &scopflow->Nx);
-  CHKERRQ(ierr);
+  if (issolver_ipopt)
+  {
+    /* Create vector X */
+    ierr = VecCreate(scopflow->comm->type, &scopflow->X);
+    CHKERRQ(ierr);
+    ierr = VecSetSizes(scopflow->X, scopflow->nx, PETSC_DECIDE);
+    CHKERRQ(ierr);
+    ierr = VecSetFromOptions(scopflow->X);
+    CHKERRQ(ierr);
+    ierr = VecGetSize(scopflow->X, &scopflow->Nx);
+    CHKERRQ(ierr);
 
-  ierr = VecDuplicate(scopflow->X, &scopflow->Xl);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(scopflow->X, &scopflow->Xu);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(scopflow->X, &scopflow->gradobj);
-  CHKERRQ(ierr);
+    ierr = VecDuplicate(scopflow->X, &scopflow->Xl);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(scopflow->X, &scopflow->Xu);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(scopflow->X, &scopflow->gradobj);
+    CHKERRQ(ierr);
 
-  /* Vector for constraints */
-  ierr = VecCreate(scopflow->comm->type, &scopflow->G);
-  CHKERRQ(ierr);
-  ierr = VecSetSizes(scopflow->G, scopflow->ncon, PETSC_DECIDE);
-  CHKERRQ(ierr);
+    /* Vector for constraints */
+    ierr = VecCreate(scopflow->comm->type, &scopflow->G);
+    CHKERRQ(ierr);
+    ierr = VecSetSizes(scopflow->G, scopflow->ncon, PETSC_DECIDE);
+    CHKERRQ(ierr);
 
-  ierr = VecSetFromOptions(scopflow->G);
-  CHKERRQ(ierr);
+    ierr = VecSetFromOptions(scopflow->G);
+    CHKERRQ(ierr);
 
-  ierr = VecGetSize(scopflow->G, &scopflow->Ncon);
-  CHKERRQ(ierr);
+    ierr = VecGetSize(scopflow->G, &scopflow->Ncon);
+    CHKERRQ(ierr);
 
-  /* Constraint bounds vectors  */
-  ierr = VecDuplicate(scopflow->G, &scopflow->Gl);
-  CHKERRQ(ierr);
-  ierr = VecDuplicate(scopflow->G, &scopflow->Gu);
-  CHKERRQ(ierr);
+    /* Constraint bounds vectors  */
+    ierr = VecDuplicate(scopflow->G, &scopflow->Gl);
+    CHKERRQ(ierr);
+    ierr = VecDuplicate(scopflow->G, &scopflow->Gu);
+    CHKERRQ(ierr);
+
+    /* Lagrangian multipliers */
+    ierr = VecDuplicate(scopflow->G, &scopflow->Lambda);
+    CHKERRQ(ierr);
+  }
 
   /* The matrices are not used in parallel, so we don't need to create them */
   if (scopflow->comm->size == 1) {
@@ -1006,10 +1016,6 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
                         PETSC_FALSE);
     CHKERRQ(ierr);
   }
-
-  /* Lagrangian multipliers */
-  ierr = VecDuplicate(scopflow->G, &scopflow->Lambda);
-  CHKERRQ(ierr);
 
   ierr = (*scopflow->solverops.setup)(scopflow);
   CHKERRQ(ierr);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -801,7 +801,8 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
       if (scopflow->cstart + c == 0) { /* First stage */
         ierr = OPFLOWSetModel(scopflow->opflows[c], scopflow->subproblem_model);
         CHKERRQ(ierr);
-        ierr = OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
+        ierr =
+            OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
         CHKERRQ(ierr);
         ierr = OPFLOWSetObjectiveType(scopflow->opflows[c], MIN_GEN_COST);
         CHKERRQ(ierr);
@@ -810,7 +811,8 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
         CHKERRQ(ierr); /* Activates ramping variables */
         ierr = OPFLOWSetModel(scopflow->opflows[c], scopflow->subproblem_model);
         CHKERRQ(ierr);
-        ierr = OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
+        ierr =
+            OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
         CHKERRQ(ierr);
         //	ierr = OPFLOWSetObjectiveType(scopflow->opflows[c], NO_OBJ);
         CHKERRQ(ierr);
@@ -936,8 +938,7 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
 
   ierr = PetscStrcmp(scopflow->solvername.c_str(), "IPOPT", &issolver_ipopt);
   CHKERRQ(ierr);
-  if (issolver_ipopt)
-  {
+  if (issolver_ipopt) {
     /* Create vector X */
     ierr = VecCreate(scopflow->comm->type, &scopflow->X);
     CHKERRQ(ierr);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -652,8 +652,8 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
 
   ExaGOLog(EXAGO_LOG_INFO,
            "SCOPFLOW running with {:d} subproblems (base case + {:d} "
-           "contingencies)",
-           scopflow->nc, scopflow->nc - 1);
+           "contingencies) globally; {:d} subproblems locally",
+           scopflow->Nc, scopflow->Nc - 1, scopflow->nc);
 
   /* Set model */
   if (!scopflow->ismultiperiod) {

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -695,11 +695,9 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
     ierr = OPFLOWIgnoreLineflowConstraints(
         scopflow->opflow0, scopflow->ignore_lineflow_constraints);
     CHKERRQ(ierr);
-    /* Base-case problem model should be POWER_BALANCE_POLAR */
-    ierr = OPFLOWSetModel(scopflow->opflow0, OPFLOWMODEL_PBPOL);
+    ierr = OPFLOWSetModel(scopflow->opflow0, scopflow->subproblem_model);
     CHKERRQ(ierr);
-    /* Base-case problem solver should be IPOPT */
-    ierr = OPFLOWSetSolver(scopflow->opflow0, OPFLOWSOLVER_IPOPT);
+    ierr = OPFLOWSetSolver(scopflow->opflow0, scopflow->subproblem_solver);
     CHKERRQ(ierr);
     ierr = OPFLOWReadMatPowerData(scopflow->opflow0, scopflow->netfile);
     CHKERRQ(ierr);
@@ -801,7 +799,7 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
       }
 
       if (scopflow->cstart + c == 0) { /* First stage */
-        ierr = OPFLOWSetModel(scopflow->opflows[c], OPFLOWMODEL_PBPOL);
+        ierr = OPFLOWSetModel(scopflow->opflows[c], scopflow->subproblem_model);
         CHKERRQ(ierr);
         ierr = OPFLOWSetSolver(scopflow->opflows[c], OPFLOWSOLVER_IPOPT);
         CHKERRQ(ierr);
@@ -810,9 +808,9 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
       } else { /* Second stages */
         ierr = OPFLOWHasGenSetPoint(scopflow->opflows[c], PETSC_TRUE);
         CHKERRQ(ierr); /* Activates ramping variables */
-        ierr = OPFLOWSetModel(scopflow->opflows[c], OPFLOWMODEL_PBPOL);
+        ierr = OPFLOWSetModel(scopflow->opflows[c], scopflow->subproblem_model);
         CHKERRQ(ierr);
-        ierr = OPFLOWSetSolver(scopflow->opflows[c], OPFLOWSOLVER_IPOPT);
+        ierr = OPFLOWSetSolver(scopflow->opflows[c], scopflow->subproblem_solver);
         CHKERRQ(ierr);
         //	ierr = OPFLOWSetObjectiveType(scopflow->opflows[c], NO_OBJ);
         CHKERRQ(ierr);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -697,7 +697,8 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
     CHKERRQ(ierr);
     ierr = OPFLOWSetModel(scopflow->opflow0, scopflow->subproblem_model);
     CHKERRQ(ierr);
-    ierr = OPFLOWSetSolver(scopflow->opflow0, scopflow->subproblem_solver);
+    /* Base-case problem solver should be IPOPT */
+    ierr = OPFLOWSetSolver(scopflow->opflow0, OPFLOWSOLVER_IPOPT);
     CHKERRQ(ierr);
     ierr = OPFLOWReadMatPowerData(scopflow->opflow0, scopflow->netfile);
     CHKERRQ(ierr);

--- a/src/scopflow/interface/scopflow.cpp
+++ b/src/scopflow/interface/scopflow.cpp
@@ -695,7 +695,8 @@ PetscErrorCode SCOPFLOWSetUp(SCOPFLOW scopflow) {
     ierr = OPFLOWIgnoreLineflowConstraints(
         scopflow->opflow0, scopflow->ignore_lineflow_constraints);
     CHKERRQ(ierr);
-    ierr = OPFLOWSetModel(scopflow->opflow0, scopflow->subproblem_model);
+    /* Base-case problem model should be POWER_BALANCE_POLAR */
+    ierr = OPFLOWSetModel(scopflow->opflow0, OPFLOWMODEL_PBPOL);
     CHKERRQ(ierr);
     /* Base-case problem solver should be IPOPT */
     ierr = OPFLOWSetSolver(scopflow->opflow0, OPFLOWSOLVER_IPOPT);

--- a/tests/functionality/opflow/CMakeLists.txt
+++ b/tests/functionality/opflow/CMakeLists.txt
@@ -131,7 +131,6 @@ if(EXAGO_INSTALL_TESTS)
     ${CMAKE_SOURCE_DIR}
     DEPENDS
     IPOPT
-    HIOP
   )
 
   exago_add_test(

--- a/tests/functionality/scopflow/CMakeLists.txt
+++ b/tests/functionality/scopflow/CMakeLists.txt
@@ -131,6 +131,7 @@ if(EXAGO_INSTALL_TESTS)
     DEPENDS
     IPOPT
     HIOP
+    RAJA
     COMMAND
     ${MPICMD}
     "-n"

--- a/tests/functionality/sopflow/CMakeLists.txt
+++ b/tests/functionality/sopflow/CMakeLists.txt
@@ -68,6 +68,7 @@ if(EXAGO_INSTALL_TESTS)
     IPOPT
     HIOP
     GPU
+    RAJA
     COMMAND
     ${RUNCMD}
     $<TARGET_FILE:test_sopflow_functionality>
@@ -126,6 +127,7 @@ if(EXAGO_INSTALL_TESTS)
     DEPENDS
     IPOPT
     GPU
+    RAJA
     COMMAND
     ${RUNCMD}
     $<TARGET_FILE:test_sopflow_functionality>
@@ -140,6 +142,7 @@ if(EXAGO_INSTALL_TESTS)
     DEPENDS
     IPOPT
     GPU
+    RAJA
     COMMAND
     ${MPICMD}
     "-n"


### PR DESCRIPTION
**Merge request type**
- [ ] New feature
- [x] Resolves bug
- [ ] Documentation
- [ ] Other

**Relates to**
- [ ] OPFLOW
- [ ] SOPFLOW
- [x] SCOPFLOW
- [ ] TCOPFLOW
- [x] CMake build system
- [ ] Spack configuration
- [ ] Manual
- [ ] Web docs
- [ ] Other

**This MR updates**
- [x] Header files
- [x] Source code
- [x] CMake build system
- [ ] Spack configuration
- [ ] Web docs
- [ ] Manual
- [ ] Other

**Summary**

- Similar to #204, only create global solution vectors when using IPOPT as `scopflow_solver`. Without this, the code crashes past a certain number of subproblems with EMPAR.
- Attempts to enable running with `DCOPF` as the `scopflow_subproblem_solver` -- Needs review
- Minor fixes in CMake for test dependencies

**Linked Issue(s)**
